### PR TITLE
VC-3547 add basic null checking for match op

### DIFF
--- a/src/Tests/VCEL.Test/ToJSCodeTests.cs
+++ b/src/Tests/VCEL.Test/ToJSCodeTests.cs
@@ -17,7 +17,7 @@ namespace VCEL.Test
 
         [TestCase("t == 'C'", "(vcelContext.t === 'C')")]
         [TestCase("(D > 500000 or D < -500000)", "((vcelContext.D > 500000) || (vcelContext.D < -500000))")]
-        [TestCase("code matches '(?:.+,|^)([0-9]\\d\\d)(?:,.+|$)'", "vcelContext.code.match('(?:.+,|^)([0-9]\\d\\d)(?:,.+|$)') !== null")]
+        [TestCase("code matches '(?:.+,|^)([0-9]\\d\\d)(?:,.+|$)'", "vcelContext.code?.match('(?:.+,|^)([0-9]\\d\\d)(?:,.+|$)') !== undefined")]
         [TestCase("(K == 'C' or K == 'AC')", "((vcelContext.K === 'C') || (vcelContext.K === 'AC'))")]
         [TestCase("(a < t and a > 0)", "((vcelContext.a < vcelContext.t) && (vcelContext.a > 0))")]
         [TestCase("s == 'ACTIVE'", "(vcelContext.s === 'ACTIVE')")]

--- a/src/Tests/VCEL.Test/ToJSCodeTests.cs
+++ b/src/Tests/VCEL.Test/ToJSCodeTests.cs
@@ -17,7 +17,7 @@ namespace VCEL.Test
 
         [TestCase("t == 'C'", "(vcelContext.t === 'C')")]
         [TestCase("(D > 500000 or D < -500000)", "((vcelContext.D > 500000) || (vcelContext.D < -500000))")]
-        [TestCase("code matches '(?:.+,|^)([0-9]\\d\\d)(?:,.+|$)'", "vcelContext.code?.match('(?:.+,|^)([0-9]\\d\\d)(?:,.+|$)') !== undefined")]
+        [TestCase("code matches '(?:.+,|^)([0-9]\\d\\d)(?:,.+|$)'", "new RegExp('(?:.+,|^)([0-9]\\d\\d)(?:,.+|$)').test(vcelContext.code)")]
         [TestCase("(K == 'C' or K == 'AC')", "((vcelContext.K === 'C') || (vcelContext.K === 'AC'))")]
         [TestCase("(a < t and a > 0)", "((vcelContext.a < vcelContext.t) && (vcelContext.a > 0))")]
         [TestCase("s == 'ACTIVE'", "(vcelContext.s === 'ACTIVE')")]

--- a/src/VCEL.JS/Expression/ToJsMatchesOp.cs
+++ b/src/VCEL.JS/Expression/ToJsMatchesOp.cs
@@ -18,7 +18,7 @@ namespace VCEL.JS.Expression
 
         public override string Evaluate(object lv, object rv)
         {
-            return $"{lv}.match({rv}) !== null";
+            return $"{lv}?.match({rv}) !== undefined";
         }
     }
 }

--- a/src/VCEL.JS/Expression/ToJsMatchesOp.cs
+++ b/src/VCEL.JS/Expression/ToJsMatchesOp.cs
@@ -18,7 +18,7 @@ namespace VCEL.JS.Expression
 
         public override string Evaluate(object lv, object rv)
         {
-            return $"{lv}?.match({rv}) !== undefined";
+            return $"new RegExp({rv}).test({lv})";
         }
     }
 }


### PR DESCRIPTION
The reason I change null to undefined is that.
e.g. "abc?.match('regex') !== null" 
if abc is null, then it will return undefined, so it will be evaluated to true.