### PR TITLE
update publish script

### DIFF
--- a/.github/workflows/dotnet-core-publish.yml
+++ b/.github/workflows/dotnet-core-publish.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set env
-      run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Setup package source
       run: dotnet nuget add source https://nuget.pkg.github.com/EclipseTrading/index.json -n github -u EclipseTrading -p ${{secrets.GITHUB_TOKEN}} --store-password-in-clear-text
     - name: Setup .NET Core


### PR DESCRIPTION
The `set-env` command is deprecated and will be disabled on November 16th.
Updated the publish script.

reference: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/