### PR TITLE
VC-3799 use arithExpr instead of expr to avoid parsing the entire exp…

### DIFF
--- a/src/Tests/VCEL.Test/ComparisonOpTests.cs
+++ b/src/Tests/VCEL.Test/ComparisonOpTests.cs
@@ -6,6 +6,24 @@ namespace VCEL.Test
 {
     public class ComparisonOpTests
     {
+        [TestCase("Pos > 100000 or FreeTextFilter matches '(?i)123'", true)]
+        [TestCase("Pos > 10 and FreeTextFilter matches '(?i)123'", true)]
+        [TestCase("FreeTextFilter matches '(?i)123' and Pos > 10", true)]
+        [TestCase("(FreeTextFilter matches '(?i)123') and Pos > 10", true)]
+        public void ComparsionMatchWithBooleanExpr(string exprStr, bool expected)
+        {
+            var expr = VCExpression.ParseDefault(exprStr);
+
+            var obj = new
+            {
+                FreeTextFilter = "123",
+                Pos = 100
+            };
+
+            var result = expr.Expression.Evaluate(obj);
+            Assert.AreEqual(expected, result);
+        }
+
         [TestCase("'ABC' == 'ABC'", true)]
         [TestCase("'ABC' == 'DEF'", false)]
         [TestCase("'A' + 'BC' == 'ABC'", true)]

--- a/src/VCEL.Core/Lang/VCELParser.g4
+++ b/src/VCEL.Core/Lang/VCELParser.g4
@@ -50,7 +50,7 @@ equalityExpr
 
 booleanOpExpr
 	: booleanOpExpr IN setLiteral #InOp
-	| booleanOpExpr MATCHES expr #Matches
+	| booleanOpExpr MATCHES arithExpr #Matches
 	| booleanOpExpr BETWEEN betweenArgs #Between
 	| arithExpr #Arith
 	;


### PR DESCRIPTION
For example
"A matches 'abc' and B > 100"
will be parsed to   (variable)A  (match operator)matches (expr)('abc' and B > 100)