### PR TITLE
VC-5213 added custom maybe function expression

### DIFF
--- a/src/Tests/VCEL.Test/MonadTests.cs
+++ b/src/Tests/VCEL.Test/MonadTests.cs
@@ -1,5 +1,6 @@
-﻿using System.Threading.Tasks;
-using NUnit.Framework;
+﻿using NUnit.Framework;
+using System.Threading.Tasks;
+using VCEL.Core.Expression.Func;
 using VCEL.Core.Lang;
 using VCEL.Core.Monad.Tasks;
 using VCEL.Expression;
@@ -85,6 +86,27 @@ namespace VCEL.Test
             var expr = VCExpression.ParseMaybe("A / B / C * 100");
             var res = expr.Expression.Evaluate(new { A = 1.0, B = 1.0, C = double.NaN });
             Assert.That(res.Value, Is.EqualTo(double.NaN));
+        }
+
+        [Test]
+        public void FunctionWithNullArgumentTest()
+        {
+            var expr = VCExpression.ParseMaybe("max(1,2,3,null)");
+            var res = expr.Expression.Evaluate(new { });
+            Assert.That(res.Value, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void CustomFunctionWithNullArgumentsTest()
+        {
+            var func = new DefaultFunctions<Maybe<object>>();
+            func.Register("GetValue", (args, context) =>
+            {
+                return args[0];
+            });
+            var expr = VCExpression.ParseMaybe("GetValue(1, null, 3, null)", func);
+            var res = expr.Expression.Evaluate(new { });
+            Assert.That(res.Value, Is.EqualTo(1));
         }
     }
 }

--- a/src/Tests/VCEL.Test/SampleExpressions.cs
+++ b/src/Tests/VCEL.Test/SampleExpressions.cs
@@ -36,9 +36,9 @@ namespace VCEL.Test
         [TestCase(Expressions.ArithExpr16)]
         [TestCase(Expressions.ArithExpr17)]
         [TestCase(Expressions.ArithExpr18, true, 0)]
-        [TestCase(Expressions.ArithExpr19)]
-        [TestCase(Expressions.ArithExpr20)]
-        [TestCase(Expressions.ArithExpr21)]
+        [TestCase(Expressions.ArithExpr19, true, null)]
+        [TestCase(Expressions.ArithExpr20, true, null)]
+        [TestCase(Expressions.ArithExpr21, true, null)]
         [TestCase(Expressions.ArithExpr22)]
         [TestCase(Expressions.ArithExpr23)]
         [TestCase(Expressions.ArithExpr24)]
@@ -136,7 +136,7 @@ namespace VCEL.Test
         [TestCase(0.04, -1.0, 0.02)]
         public void Expr5Compare(double p, double o, double expected)
         {
-            var row = new {P = p, O = o};
+            var row = new { P = p, O = o };
             foreach (var parseResult in CompositeExpression.ParseMultiple(Expressions.TestExpr5))
             {
                 var result = parseResult.Expression.Evaluate(row);
@@ -150,7 +150,7 @@ namespace VCEL.Test
         [TestCase(0.04, -1.0, 0.02)]
         public void Expr5LetGuardCompare(double p, double o, double expected)
         {
-            var row = new {P = p, O = o};
+            var row = new { P = p, O = o };
             foreach (var parseResult in CompositeExpression.ParseMultiple(Expressions.TestExpr5LetGuard))
             {
                 var letGuardResult = parseResult.Expression.Evaluate(row);
@@ -164,7 +164,7 @@ namespace VCEL.Test
         [TestCase(1.0, 1.0, 2.0)]
         public void NullCheckSum(double cpv, double ppv, double expected)
         {
-            var row = new { cpv = cpv, ppv = ppv};
+            var row = new { cpv = cpv, ppv = ppv };
             foreach (var parseResult in CompositeExpression.ParseMultiple(Expressions.NullCheckSum))
             {
                 var result = parseResult.Expression.Evaluate(row);

--- a/src/VCEL.Core/Expression/Impl/FunctionExpr.cs
+++ b/src/VCEL.Core/Expression/Impl/FunctionExpr.cs
@@ -7,7 +7,7 @@ namespace VCEL.Core.Expression.Impl
 {
     public class FunctionExpr<TMonad> : IExpression<TMonad>
     {
-        private readonly Function<TMonad> function;
+        protected readonly Function<TMonad> function;
         public FunctionExpr(
             IMonad<TMonad> monad,
             string name,
@@ -26,7 +26,7 @@ namespace VCEL.Core.Expression.Impl
         public IEnumerable<IDependency> Dependencies
             => function.Dependencies.Union(Args.SelectMany(a => a.Dependencies)).Distinct();
 
-        public TMonad Evaluate(IContext<TMonad> context)
+        public virtual TMonad Evaluate(IContext<TMonad> context)
         {
             return Eval(Args.Select(arg => arg.Evaluate(context)).ToList());
 

--- a/src/VCEL.Core/Expression/Impl/MaybeFunctionExpr.cs
+++ b/src/VCEL.Core/Expression/Impl/MaybeFunctionExpr.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using VCEL.Core.Expression.Func;
+using VCEL.Monad;
+using VCEL.Monad.Maybe;
+
+namespace VCEL.Core.Expression.Impl
+{
+    public class MaybeFunctionExpr : FunctionExpr<Maybe<object>>
+    {
+        public MaybeFunctionExpr(
+            IMonad<Maybe<object>> monad,
+            string name,
+            IReadOnlyList<IExpression<Maybe<object>>> args,
+            Function<Maybe<object>> function)
+            : base(monad, name, args, function)
+        {
+        }
+
+        public override Maybe<object> Evaluate(IContext<Maybe<object>> context)
+        {
+            var parsedArgs = Args
+                .Select(arg => arg.Evaluate(context).Value);
+
+            return Monad.Lift(function.Func(parsedArgs.ToArray(), context));
+        }
+    }
+}

--- a/src/VCEL.Core/Expression/MaybeExpressionFactory.cs
+++ b/src/VCEL.Core/Expression/MaybeExpressionFactory.cs
@@ -1,4 +1,5 @@
-﻿using VCEL.Core.Expression.Func;
+﻿using System.Collections.Generic;
+using VCEL.Core.Expression.Func;
 using VCEL.Core.Expression.Impl;
 using VCEL.Monad;
 using VCEL.Monad.Maybe;
@@ -22,5 +23,12 @@ namespace VCEL.Expression
 
         public override IExpression<Maybe<object>> NotEq(IExpression<Maybe<object>> l, IExpression<Maybe<object>> r)
             => new MaybeNotEqExpr<Maybe<object>>(Monad, l, r);
+
+        public override IExpression<Maybe<object>> Function(
+            string name,
+            IReadOnlyList<IExpression<Maybe<object>>> args) 
+            => Functions.HasFunction(name)
+                ? new MaybeFunctionExpr(Monad, name, args, Functions.GetFunction(name))
+                : throw new MissingFunctionException($"Missing function: '{name}'");
     }
 }


### PR DESCRIPTION
For function expression under maybe monad.
We dont care if the arguments are null or not.
The underlying function should handle the null case.