### PR TITLE
First class dollar symbol support

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/src/VCEL.CSharp/Expression/Func/DefaultCSharpFunctions.cs
+++ b/src/VCEL.CSharp/Expression/Func/DefaultCSharpFunctions.cs
@@ -37,7 +37,9 @@ namespace VCEL.CSharp.Expression.Func
 
             Register("now", args => $"DateTime.Now");
             Register("today", args => $"DateTime.Today");
-            FunctionHelper.RegisterEnsureArgs<string, string>("workday", args => $"VcelDateTime.Workday(VcelDateTime.ParseWorkdayParams(new object[]{{{Join(args)}}}))", Register, 2, allowNullArgument:false);
+            FunctionHelper.RegisterEnsureArgs<string, string>("workday",
+                args => $"VcelDateTime.Workday(VcelDateTime.ParseWorkdayParams(new object[]{{{Join(args)}}}))",
+                Register, 2, allowNullArgument: false);
 
             RegisterEnsureOneArg("lowercase", arg => $"{arg}.ToLower()");
             RegisterEnsureOneArg("uppercase", arg => $"{arg}.ToUpper()");

--- a/src/VCEL.CSharp/Expression/ToCSharpDivideOp.cs
+++ b/src/VCEL.CSharp/Expression/ToCSharpDivideOp.cs
@@ -13,7 +13,7 @@ namespace VCEL.CSharp.Expression
         {
         }
 
-        public override string Evaluate(object lv, object rv)
+        public override string Evaluate(object? lv, object? rv)
             =>  $"((double?){lv} / {rv})";
     }
 }

--- a/src/VCEL.Cli/VcelRepl.cs
+++ b/src/VCEL.Cli/VcelRepl.cs
@@ -339,7 +339,7 @@ namespace VCEL.Cli
             {
                 (var expression, var parsed, var outcome) = history[i];
                 var historyIndex = (history.Count - 1 - i).ToString();
-                var dependencies = string.Join(',', parsed.Expression.Dependencies.Select(dep => dep.Name));
+                var dependencies = string.Join(", ", parsed.Expression.Dependencies.Select(dep => $"{dep.Name}({dep.GetType().Name})"));
                 historyTable.AddRow(historyIndex, expression, outcome.FormatAsValue(), outcome.FormatAsType(), dependencies);
             }
             AnsiConsole.Render(historyTable);

--- a/src/VCEL.Core/Expression/Func/DefaultFunctions.cs
+++ b/src/VCEL.Core/Expression/Func/DefaultFunctions.cs
@@ -51,7 +51,8 @@ namespace VCEL.Core.Expression.Func
 
             Register("now", _ => DateTime.Now, TemporalDependency.Now);
             Register("today", _ => DateTime.Today, TemporalDependency.Today);
-            FunctionHelper.RegisterEnsureArgs<T, object>("workday", args => VcelDateTime.Workday(VcelDateTime.ParseWorkdayParams(args)), Register,2, 3, allowNullArgument:false);
+            FunctionHelper.RegisterEnsureArgs<T, object>("workday", args => VcelDateTime.Workday(VcelDateTime.ParseWorkdayParams(args)),
+                Register, 2, 3, allowNullArgument: false);
 
             RegisterEnsureOneArg("lowercase", arg => arg?.ToString().ToLower());
             RegisterEnsureOneArg("uppercase", arg => arg?.ToString().ToUpper());

--- a/src/VCEL.Core/Expression/Func/FunctionHelper.cs
+++ b/src/VCEL.Core/Expression/Func/FunctionHelper.cs
@@ -7,13 +7,13 @@ namespace VCEL.Core.Expression.Func
     public static class FunctionHelper
     {
         public static void RegisterEnsureArgs<TContext, TOut>(string name, 
-            Func<object[], TOut> func,
-            Action<string, Func<object[], IContext<TContext>, TOut>, IDependency[]> register,
+            Func<object?[], TOut> func,
+            Action<string, Func<object?[], IContext<TContext>, TOut?>, IDependency[]> register,
             int? minArgumentCount = null, 
             int? maxArgumentCount = null, 
-            bool allowNullArgument = false)
+            bool allowNullArgument = false) where TOut : class
         {
-            bool IsArgumentsValid(IReadOnlyCollection<object> args)
+            bool IsArgumentsValid(IReadOnlyCollection<object?> args)
             {
                 if (minArgumentCount != null && args.Count < minArgumentCount)
                 {

--- a/src/VCEL.Core/Expression/Impl/WorkdayParams.cs
+++ b/src/VCEL.Core/Expression/Impl/WorkdayParams.cs
@@ -5,7 +5,7 @@ namespace VCEL.Core.Expression.Impl
 {
     public class WorkdayParams
     {
-        public WorkdayParams(DateTime startDay, int noOfDays, IEnumerable<DateTime> skippedDates)
+        public WorkdayParams(DateTime startDay, int noOfDays, IReadOnlyList<DateTime> skippedDates)
         {
             StartDay = startDay;
             NoOfDays = noOfDays;
@@ -13,6 +13,6 @@ namespace VCEL.Core.Expression.Impl
         }
         public DateTime StartDay { get; }
         public int NoOfDays { get; }
-        public IEnumerable<DateTime> SkippedDates { get; }
+        public IReadOnlyList<DateTime> SkippedDates { get; }
     }
 }

--- a/src/VCEL.Core/Lang/VCELLexer.g4
+++ b/src/VCEL.Core/Lang/VCELLexer.g4
@@ -58,6 +58,7 @@ fragment TIME: TDG ':' TDG ':' TDG (DOT TDG DIGIT)?;
 
 HASH: '#';
 BAR: '|';
+DOLLAR: '$';
 
 fragment APOS: '\'' '\'';
 fragment LONG_SUFFIX: ( 'L' | 'l');
@@ -65,7 +66,7 @@ fragment HEX_DIGIT: [0-9A-Fa-f];
 
 fragment DIGIT: [0-9];
 NUMBER: DIGIT+ ([.] DIGIT+)? | '.' DIGIT+;
-ID: ('a' ..'z' | 'A' ..'Z' | '_') (
+ID: ('a' ..'z' | 'A' ..'Z' | '_' ) (
 		'a' ..'z'
 		| 'A' ..'Z'
 		| '_'

--- a/src/VCEL.Core/Lang/VCELParser.g4
+++ b/src/VCEL.Core/Lang/VCELParser.g4
@@ -104,10 +104,12 @@ term
 
 var
 	: property
-	| variable;
+	| variable
+	| dollar;
 
 property: ID;
 variable: HASH ID;
+dollar: DOLLAR;
 
 setLiteral: (OPEN_BRACE literal? (COMMA literal)* CLOSE_BRACE);
 

--- a/src/VCEL.Core/Lang/VCELVisitor.cs
+++ b/src/VCEL.Core/Lang/VCELVisitor.cs
@@ -3,11 +3,7 @@ using Antlr4.Runtime.Misc;
 using Antlr4.Runtime.Tree;
 using System;
 using System.Collections.Generic;
-using System.IO.MemoryMappedFiles;
 using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
-using VCEL.Core.Expression.Impl;
 using VCEL.Core.Helper;
 using VCEL.Expression;
 
@@ -43,6 +39,9 @@ namespace VCEL.Core.Lang
             => Compose(context, r => exprFactory.Paren(r), 1);
 
         public override ParseResult<T> VisitProperty([NotNull] VCELParser.PropertyContext context)
+            => new ParseResult<T>(exprFactory.Property(context.GetText()));
+
+        public override ParseResult<T> VisitDollar(VCELParser.DollarContext context)
             => new ParseResult<T>(exprFactory.Property(context.GetText()));
 
         public override ParseResult<T> VisitDoubleLiteral([NotNull] VCELParser.DoubleLiteralContext context)

--- a/src/VCEL.Core/VCEL.Core.csproj
+++ b/src/VCEL.Core/VCEL.Core.csproj
@@ -41,4 +41,9 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="Lang\VCELLexer.g4" />
+    <Content Include="Lang\VCELParser.g4" />
+  </ItemGroup>
+
 </Project>

--- a/src/VCEL.sln
+++ b/src/VCEL.sln
@@ -16,6 +16,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{97FF598D-7BB4-46A4-9B02-A9DB29ECF3A9}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VCEL.JS", "VCEL.JS\VCEL.JS.csproj", "{7857DF10-9A38-43BC-90BF-DA165605854B}"


### PR DESCRIPTION
- Add literal symbol `$` as a first class supported property, not a variable.
- Fix and enforce nullable checks.