### PR TITLE
Do not transform '_' named prop dependencies when creating a JS expression

### DIFF
--- a/src/Tests/VCEL.Test/ToJSCodeTests.cs
+++ b/src/Tests/VCEL.Test/ToJSCodeTests.cs
@@ -27,7 +27,7 @@ public class ToJsCodeTests
     [TestCase("(D > 500000 or D < -500000)", "((vcelContext.D > 500000) || (vcelContext.D < -500000))")]
     [TestCase("(D > 123456789)", "(vcelContext.D > 123456789)")]
     [TestCase("(D > 1234567890)", "(vcelContext.D > 1234567890)")]
-    [TestCase("(_.env.user == 'jdoe2')", "(underscoreContext._.env.user === 'jdoe2')")]
+    [TestCase("(_.env.user == 'jdoe2')", "(_.env.user === 'jdoe2')")]
     [TestCase("(env._.user == 'jdoe2')", "(vcelContext.env._.user === 'jdoe2')")]
     [TestCase("(D > 12345678901)", "(vcelContext.D > 12345678901)")]
     [TestCase("(D > 133148940000)", "(vcelContext.D > 133148940000)")]

--- a/src/Tests/VCEL.Test/ToJSCodeTests.cs
+++ b/src/Tests/VCEL.Test/ToJSCodeTests.cs
@@ -27,6 +27,8 @@ public class ToJsCodeTests
     [TestCase("(D > 500000 or D < -500000)", "((vcelContext.D > 500000) || (vcelContext.D < -500000))")]
     [TestCase("(D > 123456789)", "(vcelContext.D > 123456789)")]
     [TestCase("(D > 1234567890)", "(vcelContext.D > 1234567890)")]
+    [TestCase("(_.env.user == 'jdoe2')", "(viewclientContext._.env.user === 'jdoe2')")]
+    [TestCase("(env._.user == 'jdoe2')", "(vcelContext.env._.user === 'jdoe2')")]
     [TestCase("(D > 12345678901)", "(vcelContext.D > 12345678901)")]
     [TestCase("(D > 133148940000)", "(vcelContext.D > 133148940000)")]
     [TestCase("(D > 133148940000000)", "(vcelContext.D > 133148940000000)")]

--- a/src/Tests/VCEL.Test/ToJSCodeTests.cs
+++ b/src/Tests/VCEL.Test/ToJSCodeTests.cs
@@ -27,7 +27,7 @@ public class ToJsCodeTests
     [TestCase("(D > 500000 or D < -500000)", "((vcelContext.D > 500000) || (vcelContext.D < -500000))")]
     [TestCase("(D > 123456789)", "(vcelContext.D > 123456789)")]
     [TestCase("(D > 1234567890)", "(vcelContext.D > 1234567890)")]
-    [TestCase("(_.env.user == 'jdoe2')", "(viewclientContext._.env.user === 'jdoe2')")]
+    [TestCase("(_.env.user == 'jdoe2')", "(underscoreContext._.env.user === 'jdoe2')")]
     [TestCase("(env._.user == 'jdoe2')", "(vcelContext.env._.user === 'jdoe2')")]
     [TestCase("(D > 12345678901)", "(vcelContext.D > 12345678901)")]
     [TestCase("(D > 133148940000)", "(vcelContext.D > 133148940000)")]

--- a/src/Tests/VCEL.Test/ToJSCodeTests.cs
+++ b/src/Tests/VCEL.Test/ToJSCodeTests.cs
@@ -28,6 +28,16 @@ public class ToJsCodeTests
     [TestCase("(D > 123456789)", "(vcelContext.D > 123456789)")]
     [TestCase("(D > 1234567890)", "(vcelContext.D > 1234567890)")]
     [TestCase("(_.env.user == 'jdoe2')", "(_.env.user === 'jdoe2')")]
+    [TestCase("(_.env.user in ['jdoe2', 'tswift'])", "['jdoe2','tswift'].includes(_.env.user)")]
+    [TestCase("_.env.machine matches '(?:.+,|^)([0-9]\\d\\d)(?:,.+|$)'", "new RegExp(/(?:.+,|^)([0-9]\\d\\d)(?:,.+|$)/gm).test(_.env.machine)")]
+    [TestCase("_.env.user.startswith('jdoe')==false and P < Prev(P)",
+        "(((_.env.user?.startsWith('jdoe') ?? false) === false) && (vcelContext.P < (Prev(vcelContext.P))))")]
+    [TestCase("let usr = _.env.user in match | usr == 'jdoe2' = true | otherwise = false",
+        "(() => {let usr = _.env.user; return (() => { " +
+        "switch(true) {" +
+        "case ((usr?.valueOf() ?? null) === 'jdoe2'): return true; " +
+        "default: return false" + 
+        "}})();})()")]
     [TestCase("(env._.user == 'jdoe2')", "(vcelContext.env._.user === 'jdoe2')")]
     [TestCase("(D > 12345678901)", "(vcelContext.D > 12345678901)")]
     [TestCase("(D > 133148940000)", "(vcelContext.D > 133148940000)")]

--- a/src/VCEL.Core/Helper/Constants.cs
+++ b/src/VCEL.Core/Helper/Constants.cs
@@ -3,6 +3,6 @@
     public static class Constants
     {
         public const string DefaultContext = "vcelContext";
-        public const string ViewClientContext = "viewclientContext";
+        public const string ViewClientContext = "underscoreContext";
     }
 }

--- a/src/VCEL.Core/Helper/Constants.cs
+++ b/src/VCEL.Core/Helper/Constants.cs
@@ -3,5 +3,6 @@
     public static class Constants
     {
         public const string DefaultContext = "vcelContext";
+        public const string ViewClientContext = "viewclientContext";
     }
 }

--- a/src/VCEL.Core/Helper/Constants.cs
+++ b/src/VCEL.Core/Helper/Constants.cs
@@ -3,6 +3,5 @@
     public static class Constants
     {
         public const string DefaultContext = "vcelContext";
-        public const string ViewClientContext = "underscoreContext";
     }
 }

--- a/src/VCEL.JS/JsPropertyValueAccessor.cs
+++ b/src/VCEL.JS/JsPropertyValueAccessor.cs
@@ -50,7 +50,7 @@ namespace VCEL.JS
             return monad.Lift(jsObjContext?.Object is string
                 ? $"{context.Value}.{finalPropOrMethod}"
                 : finalPropOrMethod.Equals("_") 
-                    ? $"{Constants.ViewClientContext}.{finalPropOrMethod}" 
+                    ? $"{finalPropOrMethod}" 
                     : $"{Constants.DefaultContext}.{finalPropOrMethod}");
         }
     }

--- a/src/VCEL.JS/JsPropertyValueAccessor.cs
+++ b/src/VCEL.JS/JsPropertyValueAccessor.cs
@@ -33,7 +33,6 @@ namespace VCEL.JS
             this.propName = propName;
             this.overridePropertyFunc = overridePropertyFunc;
         }
-
         public string GetValue(IContext<string> context)
         {
             if (overridePropertyFunc != null && overridePropertyFunc.TryGetValue(propName, out var func))
@@ -50,7 +49,9 @@ namespace VCEL.JS
             var jsObjContext = context as JsObjectContext;
             return monad.Lift(jsObjContext?.Object is string
                 ? $"{context.Value}.{finalPropOrMethod}"
-                : $"{Constants.DefaultContext}.{finalPropOrMethod}");
+                : finalPropOrMethod.Equals("_") 
+                    ? $"{Constants.ViewClientContext}.{finalPropOrMethod}" 
+                    : $"{Constants.DefaultContext}.{finalPropOrMethod}");
         }
     }
 }


### PR DESCRIPTION
Evidence by the testcase:
![image](https://github.com/EclipseTrading/vcel/assets/20011860/0fb8b8e3-3a1d-47e9-bb9b-bd3724431961)
