### PR TITLE
Evaluation allocation improvements

### DIFF
--- a/.github/workflows/dotnet-core-publish.yml
+++ b/.github/workflows/dotnet-core-publish.yml
@@ -24,14 +24,14 @@ jobs:
       working-directory: src
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore /p:Version=${{ env.RELEASE_VERSION }}
+      run: dotnet build --configuration Release --no-restore /p:Version=${{ env.RELEASE_VERSION }} -p:TargetFramework=net6.0
       working-directory: src
     - name: Test
       working-directory: src
-      run: dotnet test --no-restore --verbosity normal
+      run: dotnet test --no-restore --verbosity normal -p:TargetFramework=net6.0
     - name: Pack NuGet
       working-directory: src
-      run: dotnet pack --configuration Release /p:Version=${{ env.RELEASE_VERSION }}
+      run: dotnet pack --configuration Release /p:Version=${{ env.RELEASE_VERSION }} -p:TargetFramework=net6.0
     - name: Push NuGet - VCEL.Core
       working-directory: src
       run: dotnet nuget push -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json VCEL.Core/bin/Release/VCEL.Core.${{ env.RELEASE_VERSION }}.nupkg

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -21,10 +21,10 @@ jobs:
         dotnet-version: 6.0.x
     - name: Install dependencies
       working-directory: src
-      run: dotnet restore
+      run: dotnet restore -p:TargetFramework=net6.0
     - name: Build
       working-directory: src
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release --no-restore -p:TargetFramework=net6.0
     - name: Test
       working-directory: src
-      run: dotnet test --no-restore --verbosity normal
+      run: dotnet test --no-restore --verbosity normal -p:TargetFramework=net6.0

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ bld/
 [Bb]in/
 [Oo]bj/
 
+# Rider
+.idea/
+
 # Visual Studio 2015 cache/options directory
 .vs/
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
     <Authors>Brian Flynn,Jeff Weng,Aaron Bloom,Will Liu,Trevor Leung,Rex Mo</Authors>
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <Features>strict</Features>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
     <Authors>Brian Flynn,Jeff Weng,Aaron Bloom,Will Liu,Trevor Leung,Rex Mo</Authors>
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <Features>strict</Features>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,5 +17,6 @@
     <PackageVersion Include="Spring.Core" Version="2.0.1" />
     <PackageVersion Include="System.CodeDom" Version="7.0.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="Antlr4" Version="4.6.6" />
     <PackageVersion Include="Antlr4.Runtime" Version="4.6.6" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.8" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.7.0" />

--- a/src/Tests/Spel.Benchmark/LogicalEvaluatorBenchmarks.cs
+++ b/src/Tests/Spel.Benchmark/LogicalEvaluatorBenchmarks.cs
@@ -1,4 +1,6 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using Spring.Expressions;
 using VCEL;
 using VCEL.Core.Helper;
@@ -7,84 +9,185 @@ using VCEL.CSharp;
 using VCEL.Monad.Maybe;
 using VCEL.Test.Shared;
 
-namespace Spel.Benchmark
+namespace Spel.Benchmark;
+
+using SpEx = IExpression;
+using VCEx = IExpression<object?>;
+using VCMaybeEx = IExpression<Maybe<object>>;
+using CSharpEx = IExpression<object?>;
+
+// [Orderer(BenchmarkDotNet.Order.SummaryOrderPolicy.FastestToSlowest)]
+[SimpleJob(RuntimeMoniker.Net60, warmupCount: 1, iterationCount: 1, baseline: true)]
+// [SimpleJob(RuntimeMoniker.Net70, warmupCount: 1, iterationCount: 1)]
+[MemoryDiagnoser]
+[InProcess]
+public class LogicalEvaluatorBenchmarks
 {
-    using SpEx = IExpression;
-    using VCEx = IExpression<object?>;
-    using VCMaybeEx = IExpression<Maybe<object>>;
-    using CSharpEx = IExpression<object?>;
+    private static readonly TestRow Row = new() { O = 1.0, P = 1.0 };
+    private static readonly object DynamicRow = new TestRow { O = 1.0, P = 1.0 }.ToDynamic();
+    private static readonly IDictionary<object, object> DictionaryRow = new Dictionary<object, object> { ["O"] = 1.0, ["P"] = 1.0 };
 
-    [MemoryDiagnoser]
-    [Orderer(BenchmarkDotNet.Order.SummaryOrderPolicy.FastestToSlowest)]
-    [RankColumn]
-    public class LogicalEvaluatorBenchmarks
-    {
-        private static readonly TestRow Row = new TestRow { O = 1.0, P = 1.0 };
-        private static readonly object DynamicRow = new TestRow { O = 1.0, P = 1.0 }.ToDynamic();
+    private static readonly SpEx SpelNotExpr = Expression.Parse(Expressions.Not);
+    private static readonly SpEx SpelAndExpr = Expression.Parse(Expressions.And);
+    private static readonly SpEx SpelOrExpr = Expression.Parse(Expressions.Or);
+    private static readonly SpEx SpelTernExpr = Expression.Parse(Expressions.Tern);
 
-        private static readonly SpEx SpelNotExpr = Expression.Parse(Expressions.Not);
-        private static readonly SpEx SpelAndExpr = Expression.Parse(Expressions.And);
-        private static readonly SpEx SpelOrExpr = Expression.Parse(Expressions.Or);
-        private static readonly SpEx SpelTernExpr = Expression.Parse(Expressions.Tern);
+    private static readonly VCEx VcelDefaultNotExpr = VCExpression.ParseDefault(Expressions.Not).Expression;
+    private static readonly VCEx VcelDefaultAndExpr = VCExpression.ParseDefault(Expressions.And).Expression;
+    private static readonly VCEx VcelDefaultOrExpr = VCExpression.ParseDefault(Expressions.Or).Expression;
+    private static readonly VCEx VcelDefaultTernExpr = VCExpression.ParseDefault(Expressions.Tern).Expression;
 
-        private static readonly VCEx VcelDefaultNotExpr = VCExpression.ParseDefault(Expressions.Not).Expression;
-        private static readonly VCEx VcelDefaultAndExpr = VCExpression.ParseDefault(Expressions.And).Expression;
-        private static readonly VCEx VcelDefaultOrExpr = VCExpression.ParseDefault(Expressions.Or).Expression;
-        private static readonly VCEx VcelDefaultTernExpr = VCExpression.ParseDefault(Expressions.Tern).Expression;
+    private static readonly VCMaybeEx VcelMaybeNotExpr = VCExpression.ParseMaybe(Expressions.Not).Expression;
+    private static readonly VCMaybeEx VcelMaybeAndExpr = VCExpression.ParseMaybe(Expressions.And).Expression;
+    private static readonly VCMaybeEx VcelMaybeOrExpr = VCExpression.ParseMaybe(Expressions.Or).Expression;
+    private static readonly VCMaybeEx VcelMaybeTernExpr = VCExpression.ParseMaybe(Expressions.Tern).Expression;
 
-        private static readonly VCMaybeEx VcelMaybeNotExpr = VCExpression.ParseMaybe(Expressions.Not).Expression;
-        private static readonly VCMaybeEx VcelMaybeAndExpr = VCExpression.ParseMaybe(Expressions.And).Expression;
-        private static readonly VCMaybeEx VcelMaybeOrExpr = VCExpression.ParseMaybe(Expressions.Or).Expression;
-        private static readonly VCMaybeEx VcelMaybeTernExpr = VCExpression.ParseMaybe(Expressions.Tern).Expression;
+    private static readonly CSharpEx CSharpNotExpr = CSharpExpression.ParseDelegate(Expressions.Not).Expression;
+    private static readonly CSharpEx CSharpAndExpr = CSharpExpression.ParseDelegate(Expressions.And).Expression;
+    private static readonly CSharpEx CSharpOrExpr = CSharpExpression.ParseDelegate(Expressions.Or).Expression;
+    private static readonly CSharpEx CSharpTernExpr = CSharpExpression.ParseDelegate(Expressions.Tern).Expression;
 
-        private static readonly CSharpEx CSharpNotExpr = CSharpExpression.ParseDelegate(Expressions.Not).Expression;
-        private static readonly CSharpEx CSharpAndExpr = CSharpExpression.ParseDelegate(Expressions.And).Expression;
-        private static readonly CSharpEx CSharpOrExpr = CSharpExpression.ParseDelegate(Expressions.Or).Expression;
-        private static readonly CSharpEx CSharpTernExpr = CSharpExpression.ParseDelegate(Expressions.Tern).Expression;
+    [Benchmark]
+    public void SpelNotRow() => SpelNotExpr.GetValue(Row);
 
-        [Benchmark]
-        public void SpelNot() => EvalSpel(SpelNotExpr);
-        [Benchmark]
-        public void SpelAnd() => EvalSpel(SpelAndExpr);
-        [Benchmark]
-        public void SpelOr() => EvalSpel(SpelOrExpr);
-        [Benchmark]
-        public void SpelTern() => EvalSpel(SpelTernExpr);
+    [Benchmark]
+    public void SpelNotDynamicRow() => SpelNotExpr.GetValue(DynamicRow);
 
-        [Benchmark]
-        public void VcelDefaultNot() => VcelDefaultNotExpr.Evaluate(Row);
-        [Benchmark]
-        public void VcelDefaultAnd() => VcelDefaultAndExpr.Evaluate(Row);
-        [Benchmark]
-        public void VcelDefaultOr() => VcelDefaultOrExpr.Evaluate(Row);
-        [Benchmark]
-        public void VcelDefaultTern() => VcelDefaultTernExpr.Evaluate(Row);
+    [Benchmark]
+    public void SpelNotDictionaryRow() => SpelNotExpr.GetValue(DictionaryRow);
 
-        [Benchmark]
-        public void VcelMaybeNot() => VcelMaybeNotExpr.Evaluate(Row);
-        [Benchmark]
-        public void VcelMaybeAnd() => VcelMaybeAndExpr.Evaluate(Row);
-        [Benchmark]
-        public void VcelMaybeOr() => VcelMaybeOrExpr.Evaluate(Row);
-        [Benchmark]
-        public void VcelMaybeTern() => VcelMaybeTernExpr.Evaluate(Row);
+    [Benchmark]
+    public void SpelAndRow() => SpelAndExpr.GetValue(Row);
 
-        [Benchmark]
-        public void CSharpNot() => CSharpNotExpr.Evaluate(DynamicRow);
-        [Benchmark]
-        public void CSharpAnd() => CSharpAndExpr.Evaluate(DynamicRow);
-        [Benchmark]
-        public void CSharpOr() => CSharpOrExpr.Evaluate(DynamicRow);
-        [Benchmark]
-        public void CSharpTern() => CSharpTernExpr.Evaluate(Row);
+    [Benchmark]
+    public void SpelAndDynamicRow() => SpelAndExpr.GetValue(DynamicRow);
 
-        private void EvalSpel(SpEx expression)
-        {
-            try
-            {
-                expression.GetValue(Row);
-            }
-            catch { }
-        }
-    }
+    [Benchmark]
+    public void SpelAndDictionaryRow() => SpelAndExpr.GetValue(DictionaryRow);
+
+    [Benchmark]
+    public void SpelOrRow() => SpelOrExpr.GetValue(Row);
+
+    [Benchmark]
+    public void SpelOrDynamicRow() => SpelOrExpr.GetValue(DynamicRow);
+
+    [Benchmark]
+    public void SpelOrDictionaryRow() => SpelOrExpr.GetValue(DictionaryRow);
+
+    [Benchmark]
+    public void SpelTernRow() => SpelTernExpr.GetValue(Row);
+
+    [Benchmark]
+    public void SpelTernDynamicRow() => SpelTernExpr.GetValue(DynamicRow);
+
+    [Benchmark]
+    public void SpelTernDictionaryRow() => SpelTernExpr.GetValue(DictionaryRow);
+
+    [Benchmark]
+    public void VcelDefaultNotRow() => VcelDefaultNotExpr.Evaluate(Row);
+
+    [Benchmark]
+    public void VcelDefaultNotDynamicRow() => VcelDefaultNotExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void VcelDefaultNotDictionaryRow() => VcelDefaultNotExpr.Evaluate(DictionaryRow);
+
+    [Benchmark]
+    public void VcelDefaultAndRow() => VcelDefaultAndExpr.Evaluate(Row);
+
+    [Benchmark]
+    public void VcelDefaultAndDynamicRow() => VcelDefaultAndExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void VcelDefaultAndDictionaryRow() => VcelDefaultAndExpr.Evaluate(DictionaryRow);
+
+    [Benchmark]
+    public void VcelDefaultOrRow() => VcelDefaultOrExpr.Evaluate(Row);
+
+    [Benchmark]
+    public void VcelDefaultOrDynamicRow() => VcelDefaultOrExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void VcelDefaultOrDictionaryRow() => VcelDefaultOrExpr.Evaluate(DictionaryRow);
+
+    [Benchmark]
+    public void VcelDefaultTernRow() => VcelDefaultTernExpr.Evaluate(Row);
+
+    [Benchmark]
+    public void VcelDefaultTernDynamicRow() => VcelDefaultTernExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void VcelDefaultTernDictionaryRow() => VcelDefaultTernExpr.Evaluate(DictionaryRow);
+
+    [Benchmark]
+    public void VcelMaybeNotRow() => VcelMaybeNotExpr.Evaluate(Row);
+
+    [Benchmark]
+    public void VcelMaybeNotDynamicRow() => VcelMaybeNotExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void VcelMaybeNotDictionaryRow() => VcelMaybeNotExpr.Evaluate(DictionaryRow);
+
+    [Benchmark]
+    public void VcelMaybeAndRow() => VcelMaybeAndExpr.Evaluate(Row);
+
+    [Benchmark]
+    public void VcelMaybeAndDynamicRow() => VcelMaybeAndExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void VcelMaybeAndDictionaryRow() => VcelMaybeAndExpr.Evaluate(DictionaryRow);
+
+    [Benchmark]
+    public void VcelMaybeOrRow() => VcelMaybeOrExpr.Evaluate(Row);
+
+    [Benchmark]
+    public void VcelMaybeOrDynamicRow() => VcelMaybeOrExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void VcelMaybeOrDictionaryRow() => VcelMaybeOrExpr.Evaluate(DictionaryRow);
+
+    [Benchmark]
+    public void VcelMaybeTernRow() => VcelMaybeTernExpr.Evaluate(Row);
+
+    [Benchmark]
+    public void VcelMaybeTernDynamicRow() => VcelMaybeTernExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void VcelMaybeTernDictionaryRow() => VcelMaybeTernExpr.Evaluate(DictionaryRow);
+
+    [Benchmark]
+    public void CSharpNotRow() => CSharpNotExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void CSharpNotDynamicRow() => CSharpNotExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void CSharpNotDictionaryRow() => CSharpNotExpr.Evaluate(DictionaryRow);
+
+    [Benchmark]
+    public void CSharpAndRow() => CSharpAndExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void CSharpAndDynamicRow() => CSharpAndExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void CSharpAndDictionaryRow() => CSharpAndExpr.Evaluate(DictionaryRow);
+
+    [Benchmark]
+    public void CSharpOrRow() => CSharpOrExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void CSharpOrDynamicRow() => CSharpOrExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void CSharpOrDictionaryRow() => CSharpOrExpr.Evaluate(DictionaryRow);
+
+    [Benchmark]
+    public void CSharpTernRow() => CSharpTernExpr.Evaluate(Row);
+
+    [Benchmark]
+    public void CSharpTernDynamicRow() => CSharpTernExpr.Evaluate(DynamicRow);
+
+    [Benchmark]
+    public void CSharpTernDictionaryRow() => CSharpTernExpr.Evaluate(DictionaryRow);
 }

--- a/src/Tests/Spel.Benchmark/LogicalEvaluatorBenchmarks.cs
+++ b/src/Tests/Spel.Benchmark/LogicalEvaluatorBenchmarks.cs
@@ -17,10 +17,10 @@ using VCMaybeEx = IExpression<Maybe<object>>;
 using CSharpEx = IExpression<object?>;
 
 // [Orderer(BenchmarkDotNet.Order.SummaryOrderPolicy.FastestToSlowest)]
-[SimpleJob(RuntimeMoniker.Net60, warmupCount: 1, iterationCount: 1, baseline: true)]
-// [SimpleJob(RuntimeMoniker.Net70, warmupCount: 1, iterationCount: 1)]
-[MemoryDiagnoser]
-[InProcess]
+// [SimpleJob(RuntimeMoniker.Net60, warmupCount: 1, iterationCount: 1, baseline: true)]
+// [SimpleJob(RuntimeMoniker.Net80, warmupCount: 1, iterationCount: 1)]
+// [MemoryDiagnoser]
+// [InProcess]
 public class LogicalEvaluatorBenchmarks
 {
     private static readonly TestRow Row = new() { O = 1.0, P = 1.0 };

--- a/src/Tests/Spel.Benchmark/LogicalEvaluatorBenchmarks.cs
+++ b/src/Tests/Spel.Benchmark/LogicalEvaluatorBenchmarks.cs
@@ -17,9 +17,9 @@ using VCMaybeEx = IExpression<Maybe<object>>;
 using CSharpEx = IExpression<object?>;
 
 // [Orderer(BenchmarkDotNet.Order.SummaryOrderPolicy.FastestToSlowest)]
-// [SimpleJob(RuntimeMoniker.Net60, warmupCount: 1, iterationCount: 1, baseline: true)]
+[SimpleJob(RuntimeMoniker.Net60, warmupCount: 3, iterationCount: 3, baseline: true)]
 // [SimpleJob(RuntimeMoniker.Net80, warmupCount: 1, iterationCount: 1)]
-// [MemoryDiagnoser]
+[MemoryDiagnoser]
 // [InProcess]
 public class LogicalEvaluatorBenchmarks
 {

--- a/src/Tests/Spel.Benchmark/Program.cs
+++ b/src/Tests/Spel.Benchmark/Program.cs
@@ -1,13 +1,41 @@
-﻿using BenchmarkDotNet.Running;
-using VCEL;
+﻿using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Mathematics;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 
-namespace Spel.Benchmark
+namespace Spel.Benchmark;
+
+class Program
 {
-    class Program
+    public static void Main(string[] args)
     {
-        public static void Main(string[] args)
-        {
-            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
-        }
+        // new DefaultConfig()
+        var config = new ManualConfig()
+            .AddDiagnoser(MemoryDiagnoser.Default)
+            .AddExporter(MarkdownExporter.Default)
+            .AddColumn(new RankColumn(NumeralSystem.Roman))
+            .AddJob(Job
+                .ShortRun
+                .WithWarmupCount(1).WithIterationCount(1)
+                .WithRuntime(CoreRuntime.Core60)
+                .WithLaunchCount(1)
+                .WithToolchain(InProcessNoEmitToolchain.Instance)
+            )
+            .AddJob(Job
+                .ShortRun
+                .WithWarmupCount(1).WithIterationCount(1)
+                .WithRuntime(CoreRuntime.Core70)
+                .WithLaunchCount(1)
+                .WithToolchain(InProcessNoEmitToolchain.Instance)
+            );
+
+        _ = BenchmarkSwitcher
+            .FromTypes(new[] { typeof(LogicalEvaluatorBenchmarks) })
+            .Run(args);
     }
 }

--- a/src/Tests/Spel.Benchmark/Program.cs
+++ b/src/Tests/Spel.Benchmark/Program.cs
@@ -4,9 +4,10 @@ using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Mathematics;
 using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+using Perfolizer.Horology;
 
 namespace Spel.Benchmark;
 
@@ -14,28 +15,30 @@ class Program
 {
     public static void Main(string[] args)
     {
-        // new DefaultConfig()
-        var config = new ManualConfig()
+        var config = ManualConfig
+            .CreateEmpty()
             .AddDiagnoser(MemoryDiagnoser.Default)
             .AddExporter(MarkdownExporter.Default)
+            .AddLogger(new ConsoleLogger())
             .AddColumn(new RankColumn(NumeralSystem.Roman))
-            .AddJob(Job
-                .ShortRun
-                .WithWarmupCount(1).WithIterationCount(1)
+            .AddJob(Job.ShortRun
+                .AsBaseline()
                 .WithRuntime(CoreRuntime.Core60)
-                .WithLaunchCount(1)
-                .WithToolchain(InProcessNoEmitToolchain.Instance)
+                // .WithToolchain(InProcessNoEmitToolchain.Instance)
+                .WithWarmupCount(3)
+                .WithIterationCount(3)
+                .WithIterationTime(TimeInterval.FromMilliseconds(200))
             )
-            .AddJob(Job
-                .ShortRun
-                .WithWarmupCount(1).WithIterationCount(1)
-                .WithRuntime(CoreRuntime.Core70)
-                .WithLaunchCount(1)
-                .WithToolchain(InProcessNoEmitToolchain.Instance)
+            .AddJob(Job.ShortRun
+                .WithRuntime(CoreRuntime.Core80)
+                // .WithToolchain(InProcessNoEmitToolchain.Instance)
+                .WithWarmupCount(3)
+                .WithIterationCount(3)
+                .WithIterationTime(TimeInterval.FromMilliseconds(200))
             );
 
         _ = BenchmarkSwitcher
             .FromTypes(new[] { typeof(LogicalEvaluatorBenchmarks) })
-            .Run(args);
+            .Run(args, config);
     }
 }

--- a/src/Tests/Spel.Benchmark/Program.cs
+++ b/src/Tests/Spel.Benchmark/Program.cs
@@ -39,6 +39,6 @@ class Program
 
         _ = BenchmarkSwitcher
             .FromTypes(new[] { typeof(LogicalEvaluatorBenchmarks) })
-            .Run(args, config);
+            .Run(args);
     }
 }

--- a/src/Tests/Spel.Benchmark/Spel.Benchmark.csproj
+++ b/src/Tests/Spel.Benchmark/Spel.Benchmark.csproj
@@ -2,11 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <StartupObject>Spel.Benchmark.Program</StartupObject>
-    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
-    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Spel.Benchmark/Spel.Benchmark.csproj
+++ b/src/Tests/Spel.Benchmark/Spel.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <StartupObject>Spel.Benchmark.Program</StartupObject>
   </PropertyGroup>
 

--- a/src/Tests/Spel.Benchmark/Spel.Benchmark.csproj
+++ b/src/Tests/Spel.Benchmark/Spel.Benchmark.csproj
@@ -2,12 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <StartupObject>Spel.Benchmark.Program</StartupObject>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="Spring.Core" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VCEL.Cli/VcelRepl.cs
+++ b/src/VCEL.Cli/VcelRepl.cs
@@ -23,6 +23,7 @@ namespace VCEL.Cli
             EXPR,
             CSHARP
         }
+
         private Mode mode = Mode.EXPR;
 
 
@@ -66,7 +67,7 @@ namespace VCEL.Cli
                 return;
             }
 
-            switch(this.mode)
+            switch (this.mode)
             {
                 case Mode.EXPR:
                     EvaluateExpression(input);
@@ -86,9 +87,11 @@ namespace VCEL.Cli
             }
             catch (Exception exception)
             {
-                AnsiConsole.MarkupLine($"Exception when parsing expression. {"This should be considered a bug in VCEL.".FormatAsErrorHighlighted()}");
+                AnsiConsole.MarkupLine(
+                    $"Exception when parsing expression. {"This should be considered a bug in VCEL.".FormatAsErrorHighlighted()}");
                 AnsiConsole.WriteException(exception);
             }
+
             if (parsed == null)
             {
                 return;
@@ -100,7 +103,8 @@ namespace VCEL.Cli
 
                 foreach (var parseError in parsed.ParseErrors)
                 {
-                    AnsiConsole.MarkupLine(input.EscapeMarkup().Insert(parseError.Stop + 1, "[/]").Insert(parseError.Start, "[red underline]"));
+                    AnsiConsole.MarkupLine(input.EscapeMarkup().Insert(parseError.Stop + 1, "[/]")
+                        .Insert(parseError.Start, "[red underline]"));
                     AnsiConsole.MarkupLine("{0} (line {1}, start {2}, stop {3}, token '{4}')",
                         parseError.Message.FormatAsError(),
                         parseError.Line,
@@ -108,6 +112,7 @@ namespace VCEL.Cli
                         parseError.Stop,
                         parseError.Token.EscapeMarkup());
                 }
+
                 return;
             }
 
@@ -118,32 +123,27 @@ namespace VCEL.Cli
             }
             catch (Exception exception)
             {
-                AnsiConsole.MarkupLine($"Exception when evaluating the expression. {"This should be considered a bug in VCEL.".FormatAsErrorHighlighted()}");
+                AnsiConsole.MarkupLine(
+                    $"Exception when evaluating the expression. {"This should be considered a bug in VCEL.".FormatAsErrorHighlighted()}");
                 AnsiConsole.WriteException(exception);
             }
-            if (outcome == null)
+
+            if (outcome is not { Value: { } value })
             {
                 return;
             }
 
-            if (outcome?.HasValue == true)
+            history.Add((input, parsed, outcome.Value));
+            var formattedValue = (value switch
             {
-                history.Add((input, parsed, outcome));
-                var formattedValue = (outcome.Value switch
-                {
-                    string s => s,
-                    IEnumerable<object> e => $"[{string.Join(", ", e)}]",
-                    null => "null",
-                    _ => outcome.Value.ToString(),
-                }).EscapeMarkup();
-                var formattedValueType = outcome.Value?.GetType().Name.EscapeMarkup() ?? "null";
-                var padding = new string(' ', Console.WindowWidth - (formattedValue.Length + formattedValueType.Length));
-                AnsiConsole.MarkupLine("[gold1]{0}[/]{1}[green3]{2}[/]", formattedValue, padding, formattedValueType);
-            }
-            else
-            {
-                AnsiConsole.WriteLine("Expression has no outcome value");
-            }
+                string s => s,
+                IEnumerable<object> e => $"[{string.Join(", ", e)}]",
+                null => "null",
+                _ => outcome.Value.ToString(),
+            }).EscapeMarkup();
+            var formattedValueType = value?.GetType().Name.EscapeMarkup() ?? "null";
+            var padding = new string(' ', Console.WindowWidth - (formattedValue.Length + formattedValueType.Length));
+            AnsiConsole.MarkupLine("[gold1]{0}[/]{1}[green3]{2}[/]", formattedValue, padding, formattedValueType);
         }
 
         private void ToCSharpCode(string input)
@@ -155,9 +155,11 @@ namespace VCEL.Cli
             }
             catch (Exception exception)
             {
-                AnsiConsole.MarkupLine($"Exception when parsing expression. {"This should be considered a bug in VCEL.".FormatAsErrorHighlighted()}");
+                AnsiConsole.MarkupLine(
+                    $"Exception when parsing expression. {"This should be considered a bug in VCEL.".FormatAsErrorHighlighted()}");
                 AnsiConsole.WriteException(exception);
             }
+
             if (parsed == null)
             {
                 return;
@@ -169,7 +171,8 @@ namespace VCEL.Cli
 
                 foreach (var parseError in parsed.ParseErrors)
                 {
-                    AnsiConsole.MarkupLine(input.EscapeMarkup().Insert(parseError.Stop + 1, "[/]").Insert(parseError.Start, "[red underline]"));
+                    AnsiConsole.MarkupLine(input.EscapeMarkup().Insert(parseError.Stop + 1, "[/]")
+                        .Insert(parseError.Start, "[red underline]"));
                     AnsiConsole.MarkupLine("{0} (line {1}, start {2}, stop {3}, token '{4}')",
                         parseError.Message.FormatAsError(),
                         parseError.Line,
@@ -177,10 +180,11 @@ namespace VCEL.Cli
                         parseError.Stop,
                         parseError.Token.EscapeMarkup());
                 }
+
                 return;
             }
 
-            string outcome = parsed.Expression.Evaluate(new {});
+            string outcome = parsed.Expression.Evaluate(new { });
             AnsiConsole.MarkupLine(outcome.FormatAsValue());
         }
 
@@ -211,9 +215,11 @@ namespace VCEL.Cli
                     {
                         AnsiConsole.MarkupLine($"{".set".FormatAsCommand()} command history index must be a valid integer value");
                     }
+
                     break;
                 case ".set":
-                    AnsiConsole.MarkupLine($"{".set".FormatAsCommand()} command must define exactly one property name and optionally a history index");
+                    AnsiConsole.MarkupLine(
+                        $"{".set".FormatAsCommand()} command must define exactly one property name and optionally a history index");
                     break;
                 case ".parse" when inputParts.Length is 2:
                     ParseCommand(inputParts[1]);
@@ -228,7 +234,8 @@ namespace VCEL.Cli
                     ToggleCommand(inputParts);
                     break;
                 default:
-                    AnsiConsole.MarkupLine($"{firstPart.FormatAsCommand()} command is not recognised. Run {".help".FormatAsCommand()} for help");
+                    AnsiConsole.MarkupLine(
+                        $"{firstPart.FormatAsCommand()} command is not recognised. Run {".help".FormatAsCommand()} for help");
                     break;
             }
         }
@@ -241,8 +248,10 @@ namespace VCEL.Cli
             AnsiConsole.MarkupLine(".version".FormatAsHelpItem("Shows version"));
             AnsiConsole.MarkupLine(".exit".FormatAsHelpItem("Exits the application"));
             AnsiConsole.MarkupLine(".set".FormatAsHelpItem("Adds the most recent expression outcome as a named property", "NAME"));
-            AnsiConsole.MarkupLine(".set".FormatAsHelpItem("Adds the expression outcome at the provided history index as a named property", "NAME", "INDEX"));
-            AnsiConsole.MarkupLine(".parse".FormatAsHelpItem("Parse expressions in the file into CSharp code. Display failed ones", "FILENAME"));
+            AnsiConsole.MarkupLine(".set".FormatAsHelpItem("Adds the expression outcome at the provided history index as a named property",
+                "NAME", "INDEX"));
+            AnsiConsole.MarkupLine(".parse".FormatAsHelpItem("Parse expressions in the file into CSharp code. Display failed ones",
+                "FILENAME"));
             AnsiConsole.MarkupLine(".list".FormatAsHelpItem("Shows a list of set properties; their names, values and types"));
             AnsiConsole.MarkupLine(".history".FormatAsHelpItem("Shows the history of evaluated expressions and their outcomes"));
             AnsiConsole.MarkupLine(".toggle".FormatAsHelpItem("Change the mode of the parser, accepts {EXPR, CSHARP, JS}", "MODE"));
@@ -256,6 +265,7 @@ namespace VCEL.Cli
                 AnsiConsole.MarkupLine($"{".set".FormatAsCommand()} history index must be a valid index");
                 return;
             }
+
             var value = history[history.Count - 1 - index];
             context[propertyName] = value.Outcome.Value;
             AnsiConsole.MarkupLine($"{propertyName.FormatAsOption()} = {value.Expression} = {value.Outcome.FormatAsValue()}");
@@ -303,16 +313,17 @@ namespace VCEL.Cli
                         }
                         catch (Exception e)
                         {
-                            AnsiConsole.MarkupLine($"Exception when parsing expression. {"This should be considered a bug in VCEL.".FormatAsErrorHighlighted()}");
+                            AnsiConsole.MarkupLine(
+                                $"Exception when parsing expression. {"This should be considered a bug in VCEL.".FormatAsErrorHighlighted()}");
                             AnsiConsole.WriteException(e);
                             AnsiConsole.MarkupLine($"Vcel expression:{$"{processedExpr}".FormatAsValue()}");
                         }
                     }
                 }
             }
-            catch(Exception e)
+            catch (Exception e)
             {
-                AnsiConsole.MarkupLine( $"Failed to process {filePath}: {e.Message}");
+                AnsiConsole.MarkupLine($"Failed to process {filePath}: {e.Message}");
             }
         }
 
@@ -323,12 +334,14 @@ namespace VCEL.Cli
                 AnsiConsole.WriteLine("Empty");
                 return;
             }
+
             var list = new Table();
             list.AddColumns("Property name", "Value", "Type");
             foreach ((var key, var value) in context)
             {
                 list.AddRow(key.FormatAsOption(), value.FormatAsValue(), value.FormatAsType());
             }
+
             AnsiConsole.Write(list);
         }
 
@@ -339,6 +352,7 @@ namespace VCEL.Cli
                 AnsiConsole.WriteLine("Empty");
                 return;
             }
+
             var historyTable = new Table();
             historyTable.AddColumns("History index", "Expression", "Outcome", "Type", "Dependencies");
             for (var i = 0; i < history.Count; i++)
@@ -348,6 +362,7 @@ namespace VCEL.Cli
                 var dependencies = string.Join(", ", parsed.Expression.Dependencies.Select(dep => $"{dep.Name}({dep.GetType().Name})"));
                 historyTable.AddRow(historyIndex, expression, outcome.FormatAsValue(), outcome.FormatAsType(), dependencies);
             }
+
             AnsiConsole.Write(historyTable);
         }
 
@@ -366,6 +381,7 @@ namespace VCEL.Cli
                         break;
                 }
             }
+
             AnsiConsole.MarkupLine($"Current mode is {$"{this.mode.ToString()}".FormatAsValue()}.");
         }
     }

--- a/src/VCEL.Cli/VcelRepl.cs
+++ b/src/VCEL.Cli/VcelRepl.cs
@@ -139,7 +139,7 @@ namespace VCEL.Cli
                 string s => s,
                 IEnumerable<object> e => $"[{string.Join(", ", e)}]",
                 null => "null",
-                _ => outcome.Value.ToString(),
+                _ => value.ToString(),
             }).EscapeMarkup();
             var formattedValueType = value?.GetType().Name.EscapeMarkup() ?? "null";
             var padding = new string(' ', Console.WindowWidth - (formattedValue.Length + formattedValueType.Length));

--- a/src/VCEL.Core/DictionaryAccessor.cs
+++ b/src/VCEL.Core/DictionaryAccessor.cs
@@ -1,22 +1,21 @@
-﻿namespace VCEL.Core
+﻿namespace VCEL.Core;
+
+public readonly struct DictionaryAccessor<T> : IValueAccessor<T>
 {
-    public class DictionaryAccessor<T> : IValueAccessor<T>
+    private readonly string propName;
+
+    public DictionaryAccessor(string propName)
     {
-        private string propName;
+        this.propName = propName;
+    }
 
-        public DictionaryAccessor(string propName)
+    public T GetValue(IContext<T> o)
+    {
+        var dictContext = (DictionaryContext<T>)o;
+        if (!dictContext.Dict.TryGetValue(propName, out var value))
         {
-            this.propName = propName;
+            return o.Monad.Unit;
         }
-
-        public T GetValue(IContext<T> o)
-        {
-            var dictContext = (DictionaryContext<T>)o;
-            if (!dictContext.Dict.TryGetValue(propName, out var value))
-            {
-                return o.Monad.Unit;
-            }
-            return o.Monad.Lift(value);
-        }
+        return o.Monad.Lift(value);
     }
 }

--- a/src/VCEL.Core/DictionaryContext.cs
+++ b/src/VCEL.Core/DictionaryContext.cs
@@ -1,44 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using VCEL.Monad;
 
-namespace VCEL.Core
+namespace VCEL.Core;
+
+public readonly struct DictionaryContext<T> : IContext<T>
 {
-    public class DictionaryContext<T> : IContext<T>
+    public DictionaryContext(IMonad<T> monad, IReadOnlyDictionary<string, object> dict)
     {
-        public DictionaryContext(IMonad<T> monad, IReadOnlyDictionary<string, object> dict)
+        this.Dict = dict;
+        this.Monad = monad;
+    }
+    public IMonad<T> Monad { get; }
+
+    public T Value => Monad.Lift(Dict);
+
+    public IReadOnlyDictionary<string, object> Dict { get; }
+
+    public IContext<T> OverrideName(string name, T br)
+        => new OverrideContext<T>(
+            this,
+            ImmutableDictionary<string, T>.Empty.SetItem(name, br));
+
+    public bool TryGetAccessor(string propName, out IValueAccessor<T> accessor)
+    {
+        accessor = new DictionaryAccessor<T>(propName);
+        return true;
+    }
+
+    public bool TryGetContext(object o, out IContext<T> context)
+    {
+        if (o is IReadOnlyDictionary<string, object> dic)
         {
-            this.Dict = dict;
-            this.Monad = monad;
-        }
-        public IMonad<T> Monad { get; }
-
-        public T Value => Monad.Lift(Dict);
-
-        public IReadOnlyDictionary<string, object> Dict { get; }
-
-        public virtual IContext<T> OverrideName(string name, T br)
-            => new OverrideContext<T>(
-                this,
-                ImmutableDictionary<string, T>.Empty.SetItem(name, br));
-
-        public bool TryGetAccessor(string propName, out IValueAccessor<T> accessor)
-        {
-            accessor = new DictionaryAccessor<T>(propName);
+            context = new DictionaryContext<T>(Monad, dic);
             return true;
         }
 
-        public bool TryGetContext(object o, out IContext<T> context)
-        {
-            if (o is IReadOnlyDictionary<string, object> dic)
-            {
-                context = new DictionaryContext<T>(Monad, dic);
-                return true;
-            }
-
-            context = new ObjectContext<T>(Monad, o);
-            return true;
-        }
+        context = new ObjectContext<T>(Monad, o);
+        return true;
     }
 }

--- a/src/VCEL.Core/Expression/Impl/BinaryExprBase.cs
+++ b/src/VCEL.Core/Expression/Impl/BinaryExprBase.cs
@@ -14,7 +14,10 @@ namespace VCEL.Core.Expression.Impl
             Monad = monad;
             Left = left;
             Right = right;
+            EvaluateFunc = Evaluate;
         }
+
+        private System.Func<object?, object?, T> EvaluateFunc { get; }
         public IExpression<T> Left { get; }
         public IExpression<T> Right { get; }
         public IMonad<T> Monad { get; }
@@ -25,7 +28,7 @@ namespace VCEL.Core.Expression.Impl
         {
             var l = Left.Evaluate(context);
             var r = Right.Evaluate(context);
-            return Monad.Bind(l, r, Evaluate);
+            return Monad.Bind(l, r, EvaluateFunc);
         }
 
         public abstract T Evaluate(object? lv, object? rv);

--- a/src/VCEL.Core/Expression/Impl/ListExpr.cs
+++ b/src/VCEL.Core/Expression/Impl/ListExpr.cs
@@ -25,7 +25,7 @@ namespace VCEL.Core.Expression.Impl
                 (c, n) =>  Monad.Bind(
                         c,
                         n is NullExpr<TMonad> 
-                            ? Monad.Lift(null!) // We want to support lists with nulls even in a maybe context
+                            ? Monad.Lift<object?>(null) // We want to support lists with nulls even in a maybe context
                             : n.Evaluate(context),
                         (list, value) =>
                         {

--- a/src/VCEL.Core/Expression/Impl/MaybeEqExpr.cs
+++ b/src/VCEL.Core/Expression/Impl/MaybeEqExpr.cs
@@ -5,7 +5,7 @@ using VCEL.Monad.Maybe;
 
 namespace VCEL.Core.Expression.Impl
 {
-    public class MaybeEqExpr<TMonad> : IExpression<TMonad> where TMonad : Maybe<object>
+    public class MaybeEqExpr<TMonad> : IExpression<TMonad> where TMonad : struct, IMaybe<object?>
     {
         public MaybeEqExpr(
             IMonad<TMonad> monad,

--- a/src/VCEL.Core/Expression/Impl/MaybeNotEqExpr.cs
+++ b/src/VCEL.Core/Expression/Impl/MaybeNotEqExpr.cs
@@ -5,7 +5,7 @@ using VCEL.Monad.Maybe;
 
 namespace VCEL.Core.Expression.Impl
 {
-    public class MaybeNotEqExpr<TMonad> : IExpression<TMonad> where TMonad : Maybe<object>
+    public class MaybeNotEqExpr<TMonad> : IExpression<TMonad> where TMonad : struct, IMaybe<object?>
     {
         public MaybeNotEqExpr(
             IMonad<TMonad> monad,

--- a/src/VCEL.Core/Expression/Impl/Ternary.cs
+++ b/src/VCEL.Core/Expression/Impl/Ternary.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using VCEL.Monad;
@@ -16,8 +17,10 @@ namespace VCEL.Core.Expression.Impl
             ConditionExpr = conditionExpr;
             TrueExpr = trueExpr;
             FalseExpr = falseExpr;
+            BindFunc = Bind;
         }
 
+        private Func<object?, IContext<TMonad>, TMonad> BindFunc { get; }
         public IExpression<TMonad> ConditionExpr { get; }
         public IExpression<TMonad> TrueExpr { get; }
         public IExpression<TMonad> FalseExpr { get; }
@@ -34,14 +37,14 @@ namespace VCEL.Core.Expression.Impl
         public TMonad Evaluate(IContext<TMonad> context)
         {
             var c = ConditionExpr.Evaluate(context);
-            return Monad.Bind(c, BindC);
+            return Monad.Bind(c, context, BindFunc);
+        }
 
-            TMonad BindC(object? res)
-            {
-                return res is bool b
-                    ? (b ? TrueExpr.Evaluate(context) : FalseExpr.Evaluate(context))
-                    : Monad.Unit;
-            }
+        private TMonad Bind(object? res, IContext<TMonad> context)
+        {
+            return res is bool b
+                ? b ? TrueExpr.Evaluate(context) : FalseExpr.Evaluate(context)
+                : Monad.Unit;
         }
     }
 }

--- a/src/VCEL.Core/Expression/Impl/UnitAccessor.cs
+++ b/src/VCEL.Core/Expression/Impl/UnitAccessor.cs
@@ -1,19 +1,18 @@
 ﻿using VCEL.Monad;
 
-namespace VCEL.Core.Expression.Impl
+namespace VCEL.Core.Expression.Impl;
+
+internal readonly struct UnitAccessor<TMonad> : IValueAccessor<TMonad>
 {
-    internal class UnitAccessor<TMonad> : IValueAccessor<TMonad>
+    private readonly IMonad<TMonad> monad;
+
+    public UnitAccessor(IMonad<TMonad> monad)
     {
-        private IMonad<TMonad> monad;
+        this.monad = monad;
+    }
 
-        public UnitAccessor(IMonad<TMonad> monad)
-        {
-            this.monad = monad;
-        }
-
-        public TMonad GetValue(IContext<TMonad> o)
-        {
-            return monad.Unit;
-        }
+    public TMonad GetValue(IContext<TMonad> o)
+    {
+        return monad.Unit;
     }
 }

--- a/src/VCEL.Core/Expression/MissingFunctionException.cs
+++ b/src/VCEL.Core/Expression/MissingFunctionException.cs
@@ -17,6 +17,7 @@ namespace VCEL.Expression
         {
         }
 
+        [Obsolete("Obsolete")]
         protected MissingFunctionException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/VCEL.Core/IContext.cs
+++ b/src/VCEL.Core/IContext.cs
@@ -1,14 +1,13 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using VCEL.Monad;
 
-namespace VCEL
+namespace VCEL;
+
+public interface IContext<T>
 {
-    public interface IContext<T>
-    {
-        bool TryGetAccessor(string propName, [NotNullWhen(true)] out IValueAccessor<T>? accessor);
-        IContext<T> OverrideName(string name, T br);
-        IMonad<T> Monad { get; }
-        bool TryGetContext(object o, [NotNullWhen(true)] out IContext<T>? context);
-        T Value { get; }
-    }
+    bool TryGetAccessor(string propName, [NotNullWhen(true)] out IValueAccessor<T>? accessor);
+    IContext<T> OverrideName(string name, T br);
+    IMonad<T> Monad { get; }
+    bool TryGetContext(object o, [NotNullWhen(true)] out IContext<T>? context);
+    T Value { get; }
 }

--- a/src/VCEL.Core/IValueAccessor.cs
+++ b/src/VCEL.Core/IValueAccessor.cs
@@ -2,6 +2,6 @@
 {
     public interface IValueAccessor<T>
     {
-        T GetValue(IContext<T> o);
+        T GetValue(IContext<T> context);
     }
 }

--- a/src/VCEL.Core/IValueAccessor.cs
+++ b/src/VCEL.Core/IValueAccessor.cs
@@ -1,7 +1,6 @@
-﻿namespace VCEL
+﻿namespace VCEL;
+
+public interface IValueAccessor<T>
 {
-    public interface IValueAccessor<T>
-    {
-        T GetValue(IContext<T> context);
-    }
+    T GetValue(IContext<T> context);
 }

--- a/src/VCEL.Core/Monad/ConcatStringMonad.cs
+++ b/src/VCEL.Core/Monad/ConcatStringMonad.cs
@@ -8,13 +8,23 @@ namespace VCEL.Expression
     {
         public string Unit => "";
         public string Bind(string m, Func<object, string> f) => f(m);
-        public string Lift(object? value) => value?.ToString() ?? string.Empty;
+        public string Lift<TValue>(TValue value) => value?.ToString() ?? string.Empty;
 
         public static ConcatStringMonad Instance { get; } = new ConcatStringMonad();
 
         public string Bind(string a, string b, Func<object, object, string> f)
         {
             return f(a, b);
+        }
+
+        public string Bind(string m, IContext<string> context, Func<object?, IContext<string>, string> f)
+        {
+            return f(m, context);
+        }
+
+        public string Bind<TValue>(string m, IContext<string> context, Func<object?, IContext<string>, TValue, string> f, TValue value)
+        {
+            return f(m, context, value);
         }
     }
 }

--- a/src/VCEL.Core/Monad/ExprMonad.cs
+++ b/src/VCEL.Core/Monad/ExprMonad.cs
@@ -5,13 +5,23 @@ namespace VCEL.Monad
     public class ExprMonad : IMonad<object?>
     {
         public object? Unit { get; } = null;
-        public object? Lift(object? value) 
+        public object? Lift<TValue>(TValue value)
         {
-            return value; 
+            return value;
         }
         public object? Bind(object? m, Func<object?, object?> f)
         {
             return f(m);
+        }
+
+        public object? Bind(object? m, IContext<object?> context, Func<object?, IContext<object?>, object?> f)
+        {
+            return f(m, context);
+        }
+
+        public object? Bind<TValue>(object? m, IContext<object?> context, Func<object?, IContext<object?>, TValue, object?> f, TValue value)
+        {
+            return f(m, context, value);
         }
 
         public object? Bind(object? a, object? b, Func<object?, object?, object?> f)

--- a/src/VCEL.Core/Monad/IMonad.cs
+++ b/src/VCEL.Core/Monad/IMonad.cs
@@ -4,8 +4,11 @@ namespace VCEL.Monad
     public interface IMonad<TMonad>
     {
         TMonad Unit { get; }
-        TMonad Lift(object? value);
+        TMonad Lift<TValue>(TValue value);
         TMonad Bind(TMonad m, Func<object?, TMonad> f);
+        TMonad Bind(TMonad m, IContext<TMonad> context, Func<object?, IContext<TMonad>, TMonad> f);
+        TMonad Bind<TValue>(TMonad m, IContext<TMonad> context, Func<object?, IContext<TMonad>, TValue, TMonad> f, TValue value);
         TMonad Bind(TMonad a, TMonad b, Func<object?, object?, TMonad> f);
+        // TMonad Bind<TValue>(TMonad a, TMonad b, TValue valueA, Func<TValue, TValue, TMonad> f);
     }
 }

--- a/src/VCEL.Core/Monad/IMonad.cs
+++ b/src/VCEL.Core/Monad/IMonad.cs
@@ -1,14 +1,60 @@
 ﻿using System;
-namespace VCEL.Monad
+
+namespace VCEL.Monad;
+
+public interface IMonad<TMonad>
 {
-    public interface IMonad<TMonad>
-    {
-        TMonad Unit { get; }
-        TMonad Lift<TValue>(TValue value);
-        TMonad Bind(TMonad m, Func<object?, TMonad> f);
-        TMonad Bind(TMonad m, IContext<TMonad> context, Func<object?, IContext<TMonad>, TMonad> f);
-        TMonad Bind<TValue>(TMonad m, IContext<TMonad> context, Func<object?, IContext<TMonad>, TValue, TMonad> f, TValue value);
-        TMonad Bind(TMonad a, TMonad b, Func<object?, object?, TMonad> f);
-        // TMonad Bind<TValue>(TMonad a, TMonad b, TValue valueA, Func<TValue, TValue, TMonad> f);
-    }
+    /// <summary>
+    /// Unit is the identity element of the monad.
+    /// </summary>
+    TMonad Unit { get; }
+
+    /// <summary>
+    /// Lift is a way to wrap a value in a monad.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <typeparam name="TValue"></typeparam>
+    /// <returns></returns>
+    TMonad Lift<TValue>(TValue value);
+
+    /// <summary>
+    /// Bind is the core operation of a monad. It allows us to chain together operations that return a monad.
+    /// </summary>
+    /// <param name="m"></param>
+    /// <param name="f"></param>
+    /// <returns></returns>
+    TMonad Bind(TMonad m, Func<object?, TMonad> f);
+
+    /// <summary>
+    /// Bind is the core operation of a monad. It allows us to chain together operations that return a monad.
+    /// This version of bind is used when we want to pass the context and avoid closure allocations.
+    /// </summary>
+    /// <param name="m"></param>
+    /// <param name="context"></param>
+    /// <param name="f"></param>
+    /// <returns></returns>
+    TMonad Bind(TMonad m, IContext<TMonad> context, Func<object?, IContext<TMonad>, TMonad> f);
+
+    /// <summary>
+    /// This bind implementation is used when we short-circuit the evaluation of the monad.
+    /// It exists to allow the context to be passed to the function in a way that avoids closure allocations.
+    /// </summary>
+    /// <param name="m"></param>
+    /// <param name="context"></param>
+    /// <param name="f"></param>
+    /// <param name="value"></param>
+    /// <typeparam name="TValue"></typeparam>
+    /// <returns></returns>
+    TMonad Bind<TValue>(TMonad m, IContext<TMonad> context, Func<object?, IContext<TMonad>, TValue, TMonad> f,
+        TValue value);
+
+    /// <summary>
+    /// Bind is the core operation of a monad. It allows us to chain together operations that return a monad.
+    /// This version of bind is used when we have two monads that we want to combine.
+    /// </summary>
+    /// <param name="a"></param>
+    /// <param name="b"></param>
+    /// <param name="f"></param>
+    /// <returns></returns>
+    TMonad Bind(TMonad a, TMonad b, Func<object?, object?, TMonad> f);
 }

--- a/src/VCEL.Core/Monad/List/ListMonad.cs
+++ b/src/VCEL.Core/Monad/List/ListMonad.cs
@@ -8,7 +8,7 @@ namespace VCEL.Core.Monad.List
     public class ListMonad<T> : IMonad<List<T>>
     {
         public List<T> Unit { get; } = new List<T>(new List<T>());
-        public List<T> Lift(object? value)
+        public List<T> Lift<TValue>(TValue value)
         {
             return value is T t ? new List<T> { t } : new List<T>();
         }
@@ -17,6 +17,26 @@ namespace VCEL.Core.Monad.List
         {
             var results = m
                 .Select(e => f(e))
+                .SelectMany(l => l)
+                .ToList();
+
+            return new List<T>(results);
+        }
+
+        public List<T> Bind(List<T> m, IContext<List<T>> context, Func<object?, IContext<List<T>>, List<T>> f)
+        {
+            var results = m
+                .Select(e => f(e, context))
+                .SelectMany(l => l)
+                .ToList();
+
+            return new List<T>(results);
+        }
+
+        public List<T> Bind<TValue>(List<T> m, IContext<List<T>> context, Func<object?, IContext<List<T>>, TValue, List<T>> f, TValue value)
+        {
+            var results = m
+                .Select(e => f(e, context, value))
                 .SelectMany(l => l)
                 .ToList();
 

--- a/src/VCEL.Core/Monad/Maybe/Maybe.cs
+++ b/src/VCEL.Core/Monad/Maybe/Maybe.cs
@@ -6,7 +6,7 @@ public interface IMaybe<out T>
     T Value { get; }
 }
 
-public struct Maybe<T> : IMaybe<T>
+public readonly struct Maybe<T> : IMaybe<T>
 {
     public Maybe(T value)
     {

--- a/src/VCEL.Core/Monad/Maybe/Maybe.cs
+++ b/src/VCEL.Core/Monad/Maybe/Maybe.cs
@@ -1,21 +1,27 @@
-﻿namespace VCEL.Monad.Maybe
+﻿namespace VCEL.Monad.Maybe;
+
+public interface IMaybe<out T>
 {
-    public class Maybe<T>
+    bool HasValue { get; }
+    T Value { get; }
+}
+
+public struct Maybe<T> : IMaybe<T>
+{
+    public Maybe(T value)
     {
-        public Maybe(T value)
-        {
-            Value = value;
-            HasValue = true;
-        }
-
-        internal Maybe() 
-        { 
-            Value = default!;
-        }
-
-        public bool HasValue { get; }
-        public T Value { get; }
-        public static Maybe<T> Some(T value) => new Maybe<T>(value);
-        public static Maybe<T> None { get; } = new Maybe<T>();
+        Value = value;
+        HasValue = true;
     }
+
+    public Maybe()
+    {
+        Value = default!;
+        HasValue = false;
+    }
+
+    public bool HasValue { get; }
+    public T Value { get; }
+    public static Maybe<T> Some(T value) => new(value);
+    public static Maybe<T> None { get; } = new();
 }

--- a/src/VCEL.Core/Monad/Maybe/MaybeMonad.cs
+++ b/src/VCEL.Core/Monad/Maybe/MaybeMonad.cs
@@ -6,22 +6,45 @@ namespace VCEL.Monad.Maybe
     {
         public Maybe<object> Unit => Maybe<object>.None;
 
-        public Maybe<object> Lift(object? value) => Maybe<object>.Some(value!);
+        public Maybe<object> Lift<TValue>(TValue value) => Maybe<object>.Some(value!);
 
         public Maybe<object> Bind(Maybe<object> a, Func<object, Maybe<object>> f)
         {
-            if(!a.HasValue)
+            if (!a.HasValue)
             {
                 return Maybe<object>.None;
             }
+
             return f(a.Value);
         }
+
+        public Maybe<object> Bind(Maybe<object> m, IContext<Maybe<object>> context, Func<object?, IContext<Maybe<object>>, Maybe<object>> f)
+        {
+            if (!m.HasValue)
+            {
+                return Maybe<object>.None;
+            }
+
+            return f(m.Value, context);
+        }
+
+        public Maybe<object> Bind<TValue>(Maybe<object> m, IContext<Maybe<object>> context, Func<object?, IContext<Maybe<object>>, TValue, Maybe<object>> f, TValue value)
+        {
+            if (!m.HasValue)
+            {
+                return Maybe<object>.None;
+            }
+
+            return f(m.Value, context, value);
+        }
+
         public Maybe<object> Bind(Maybe<object> a, Maybe<object> b, Func<object, object, Maybe<object>> f)
         {
             if (!a.HasValue || !b.HasValue)
             {
                 return Maybe<object>.None;
             }
+
             return f(a.Value, b.Value);
         }
 

--- a/src/VCEL.Core/ObjectContext.cs
+++ b/src/VCEL.Core/ObjectContext.cs
@@ -1,35 +1,34 @@
 ﻿using System.Collections.Immutable;
 using VCEL.Monad;
 
-namespace VCEL
+namespace VCEL;
+
+public readonly struct ObjectContext<TMonad> : IContext<TMonad>
 {
-    public class ObjectContext<TMonad> : IContext<TMonad>
+    public IMonad<TMonad> Monad { get; }
+
+    public object Object { get; }
+
+    public ObjectContext(IMonad<TMonad> monad, object obj)
     {
-        public IMonad<TMonad> Monad { get; }
-
-        public object Object { get; }
-
-        public ObjectContext(IMonad<TMonad> monad, object obj)
-        {
-            Monad = monad;
-            Object = obj;
-        }
-
-        public virtual IContext<TMonad> OverrideName(string name, TMonad br)
-            => new OverrideContext<TMonad>(
-                this,
-                ImmutableDictionary<string, TMonad>.Empty.SetItem(name, br));
-
-        public virtual bool TryGetAccessor(string propName, out IValueAccessor<TMonad> accessor)
-        {
-            accessor = new PropertyValueAccessor<TMonad>(Monad, propName);
-            return true;
-        }
-        public virtual bool TryGetContext(object o, out IContext<TMonad> context)
-        {
-            context = new ObjectContext<TMonad>(Monad, o);
-            return true;
-        }
-        public TMonad Value => Monad.Lift(Object);
+        Monad = monad;
+        Object = obj;
     }
+
+    public IContext<TMonad> OverrideName(string name, TMonad br)
+        => new OverrideContext<TMonad>(
+            this,
+            ImmutableDictionary<string, TMonad>.Empty.SetItem(name, br));
+
+    public bool TryGetAccessor(string propName, out IValueAccessor<TMonad> accessor)
+    {
+        accessor = new PropertyValueAccessor<TMonad>(Monad, propName);
+        return true;
+    }
+    public bool TryGetContext(object o, out IContext<TMonad> context)
+    {
+        context = new ObjectContext<TMonad>(Monad, o);
+        return true;
+    }
+    public TMonad Value => Monad.Lift(Object);
 }

--- a/src/VCEL.Core/ObjectContextEx.cs
+++ b/src/VCEL.Core/ObjectContextEx.cs
@@ -1,20 +1,19 @@
 ﻿using System.Collections.Generic;
 using VCEL.Core;
 
-namespace VCEL
-{
-    public static class ObjectContextEx
-    {
-        public static TMonad Evaluate<TMonad>(this IExpression<TMonad> expr, object o)
-        {
-            var context = new ObjectContext<TMonad>(expr.Monad, o);
-            return expr.Evaluate(context);
-        }
+namespace VCEL;
 
-        public static TMonad Evaluate<TMonad>(this IExpression<TMonad> expr, IReadOnlyDictionary<string, object> o)
-        {
-            var context = new DictionaryContext<TMonad>(expr.Monad, o);
-            return expr.Evaluate(context);
-        }
+public static class ObjectContextEx
+{
+    public static TMonad Evaluate<TMonad>(this IExpression<TMonad> expr, object o)
+    {
+        var context = new ObjectContext<TMonad>(expr.Monad, o);
+        return expr.Evaluate(context);
+    }
+
+    public static TMonad Evaluate<TMonad>(this IExpression<TMonad> expr, IReadOnlyDictionary<string, object> o)
+    {
+        var context = new DictionaryContext<TMonad>(expr.Monad, o);
+        return expr.Evaluate(context);
     }
 }

--- a/src/VCEL.Core/OverrideContext.cs
+++ b/src/VCEL.Core/OverrideContext.cs
@@ -2,46 +2,45 @@
 using System.Diagnostics.CodeAnalysis;
 using VCEL.Monad;
 
-namespace VCEL
+namespace VCEL;
+
+public readonly struct OverrideContext<TMonad> : IContext<TMonad>
 {
-    public class OverrideContext<TMonad> : IContext<TMonad>
+    private readonly IContext<TMonad> context;
+
+    public OverrideContext(IContext<TMonad> context, ImmutableDictionary<string, TMonad> overrides)
     {
-        private readonly IContext<TMonad> context;
-
-        public OverrideContext(IContext<TMonad> context, ImmutableDictionary<string, TMonad> overrides)
-        {
-            this.context = context;
-            Overrides = overrides;
-        }
-
-        public IMonad<TMonad> Monad => context.Monad;
-
-        public ImmutableDictionary<string, TMonad> Overrides { get; }
-
-        public IContext<TMonad> OverrideName(string name, TMonad br)
-        {
-            return new OverrideContext<TMonad>(
-                context,
-                Overrides.SetItem(name, br));
-        }
-
-        public bool TryGetAccessor(string propName, [NotNullWhen(true)] out IValueAccessor<TMonad>? accessor)
-        {
-            accessor = new OverrideAccessor<TMonad>(propName);
-            return true;
-        }
-
-        public bool TryGetContext(object o, [NotNullWhen(true)] out IContext<TMonad>? context)
-        {
-            context = this.context.TryGetContext(o, out var c)
-                ? new OverrideContext<TMonad>(c, this.Overrides)
-                : null;
-            return context != null;
-        }
-
-
-        public TMonad Value => context.Value;
-
-        public IContext<TMonad> BaseContext => context;
+        this.context = context;
+        Overrides = overrides;
     }
+
+    public IMonad<TMonad> Monad => context.Monad;
+
+    public ImmutableDictionary<string, TMonad> Overrides { get; }
+
+    public IContext<TMonad> OverrideName(string name, TMonad br)
+    {
+        return new OverrideContext<TMonad>(
+            context,
+            Overrides.SetItem(name, br));
+    }
+
+    public bool TryGetAccessor(string propName, [NotNullWhen(true)] out IValueAccessor<TMonad>? accessor)
+    {
+        accessor = new OverrideAccessor<TMonad>(propName);
+        return true;
+    }
+
+    public bool TryGetContext(object o, [NotNullWhen(true)] out IContext<TMonad>? context)
+    {
+        context = this.context.TryGetContext(o, out var c)
+            ? new OverrideContext<TMonad>(c, this.Overrides)
+            : null;
+        return context != null;
+    }
+
+
+    public TMonad Value => context.Value;
+
+    public IContext<TMonad> BaseContext => context;
 }

--- a/src/VCEL.Core/PropertyValueAccessor.cs
+++ b/src/VCEL.Core/PropertyValueAccessor.cs
@@ -1,41 +1,41 @@
 ﻿using System.Reflection;
 using VCEL.Monad;
 
-namespace VCEL
-{
-    public class PropertyValueAccessor<TMonad> : IValueAccessor<TMonad>
-    {
-        private bool propSet = false;
-        private PropertyInfo? prop;
-        private readonly IMonad<TMonad> monad;
-        private readonly string propName;
+namespace VCEL;
 
-        public PropertyValueAccessor(IMonad<TMonad> monad, string propName)
+public struct PropertyValueAccessor<TMonad> : IValueAccessor<TMonad>
+{
+    private bool propSet = false;
+    private PropertyInfo? prop;
+    private readonly IMonad<TMonad> monad;
+    private readonly string propName;
+
+    public PropertyValueAccessor(IMonad<TMonad> monad, string propName)
+    {
+        this.monad = monad;
+        this.propName = propName;
+        prop = null;
+    }
+
+    public TMonad GetValue(IContext<TMonad> context)
+    {
+        if (context is not ObjectContext<TMonad> { Object: { } obj } oc)
         {
-            this.monad = monad;
-            this.propName = propName;
+            return monad.Unit;
         }
 
-        public TMonad GetValue(IContext<TMonad> context)
+        var type = obj.GetType();
+        if (propSet && prop?.DeclaringType == type)
         {
-            if (context is not ObjectContext<TMonad> { Object: { } obj } oc)
-            {
-                return monad.Unit;
-            }
-
-            var type = obj.GetType();
-            if (propSet && prop?.DeclaringType == type)
-            {
-                return prop == null
-                    ? monad.Unit
-                    : monad.Lift(prop?.GetValue(oc.Object));
-            }
-
-            prop = type.GetProperty(propName);
-            propSet = true;
             return prop == null
                 ? monad.Unit
                 : monad.Lift(prop?.GetValue(oc.Object));
         }
+
+        prop = type.GetProperty(propName);
+        propSet = true;
+        return prop == null
+            ? monad.Unit
+            : monad.Lift(prop?.GetValue(oc.Object));
     }
 }

--- a/src/VCEL.JS/JsObjectContext.cs
+++ b/src/VCEL.JS/JsObjectContext.cs
@@ -1,30 +1,41 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using VCEL.Monad;
 
-namespace VCEL.JS
+namespace VCEL.JS;
+
+public class JsObjectContext : IContext<string>
 {
-    public class JsObjectContext : ObjectContext<string>
+    private readonly IReadOnlyDictionary<string, Func<string>>? overridePropertyFunc;
+    
+    public IMonad<string> Monad { get; }
+
+    public object Object { get; }
+    
+    public JsObjectContext(IMonad<string> monad, object obj, IReadOnlyDictionary<string, Func<string>>? overridePropertyFunc = null)
     {
-        private readonly IReadOnlyDictionary<string, Func<string>>? overridePropertyFunc;
+        this.overridePropertyFunc = overridePropertyFunc;
+        Monad = monad;
+        Object = obj;
+    }
 
-        public JsObjectContext(IMonad<string> monad, object obj, IReadOnlyDictionary<string, Func<string>>? overridePropertyFunc = null)
-            : base(monad, obj)
-        {
-            this.overridePropertyFunc = overridePropertyFunc;
-        }
+    public IContext<string> OverrideName(string name, string br)
+        => new OverrideContext<string>(
+            this,
+            ImmutableDictionary<string, string>.Empty.SetItem(name, br));
 
-        public override bool TryGetAccessor(string propName, out IValueAccessor<string> accessor)
-        {
-            accessor = new JsPropertyValueAccessor(Monad, propName, overridePropertyFunc);
-            accessor = new JsPropertyValueAccessor(Monad, propName, overridePropertyFunc);
-            return true;
-        }
+    public string Value => Monad.Lift(Object);
 
-        public override bool TryGetContext(object o, out IContext<string> context)
-        {
-            context = new JsObjectContext(Monad, o, overridePropertyFunc);
-            return true;
-        }
+    public bool TryGetAccessor(string propName, out IValueAccessor<string> accessor)
+    {
+        accessor = new JsPropertyValueAccessor(Monad, propName, overridePropertyFunc);
+        return true;
+    }
+
+    public bool TryGetContext(object o, out IContext<string> context)
+    {
+        context = new JsObjectContext(Monad, o, overridePropertyFunc);
+        return true;
     }
 }

--- a/src/VCEL.JS/ToJsCodeFactory.cs
+++ b/src/VCEL.JS/ToJsCodeFactory.cs
@@ -8,7 +8,7 @@ using VCEL.Monad;
 
 namespace VCEL.JS
 {
-    public class ToJsCodeFactory<IContext> : ExpressionFactory<string>
+    public class ToJsCodeFactory<TContext> : ExpressionFactory<string>
     {
         public ToJsCodeFactory(
             IMonad<string> monad,


### PR DESCRIPTION
## Main changes
- Remove closures where possible
- Move `IContext`/`IValueAccessor` to be structs, readonly where possible
- Update benchmarks

Evaluation allocations mainly now come from value type boxing and unboxing.

## Highlights
VcelDefaultAnd 248 B → 56 B
VcelMaybeAnd 280 B → 56 B
VcelMaybeTern 360 B → 136 B

## Before
| Method          | Mean      | Error      | StdDev   | Rank | Gen0   | Gen1   | Allocated |
|---------------- |----------:|-----------:|---------:|-----:|-------:|-------:|----------:|
| CSharpOr        |  13.02 ns |   8.247 ns | 0.452 ns |    1 | 0.0067 | 0.0000 |      56 B |
| CSharpAnd       |  13.04 ns |   0.774 ns | 0.042 ns |    1 | 0.0067 | 0.0000 |      56 B |
| CSharpNot       |  13.22 ns |   6.658 ns | 0.365 ns |    2 | 0.0067 |      - |      56 B |
| SpelNot         |  35.84 ns |  20.922 ns | 1.147 ns |    3 | 0.0086 |      - |      72 B |
| SpelOr          |  35.97 ns |  15.752 ns | 0.863 ns |    3 | 0.0086 |      - |      72 B |
| VcelDefaultOr   |  39.09 ns |  14.373 ns | 0.788 ns |    4 | 0.0220 | 0.0001 |     184 B |
| VcelMaybeOr     |  47.19 ns |  57.713 ns | 3.163 ns |    5 | 0.0258 |      - |     216 B |
| VcelDefaultAnd  |  51.43 ns |  14.840 ns | 0.813 ns |    6 | 0.0296 | 0.0001 |     248 B |
| SpelAnd         |  52.89 ns |   3.983 ns | 0.218 ns |    7 | 0.0086 |      - |      72 B |
| VcelMaybeAnd    |  55.35 ns |  15.051 ns | 0.825 ns |    8 | 0.0334 |      - |     280 B |
| VcelDefaultNot  |  66.09 ns |  49.006 ns | 2.686 ns |    9 | 0.0143 | 0.0001 |     120 B |
| VcelMaybeNot    |  74.07 ns |  92.847 ns | 5.089 ns |   10 | 0.0181 |      - |     152 B |
| CSharpTern      | 181.63 ns |  98.042 ns | 5.374 ns |   11 | 0.0324 |      - |     272 B |
| VcelDefaultTern | 207.18 ns |  79.348 ns | 4.349 ns |   12 | 0.0353 |      - |     296 B |
| VcelMaybeTern   | 216.48 ns |  96.338 ns | 5.281 ns |   13 | 0.0429 |      - |     360 B |
| SpelTern        | 227.58 ns | 135.860 ns | 7.447 ns |   14 | 0.0172 |      - |     144 B |

## After
| Method                       | Mean      | Error      | StdDev    | Gen0   | Gen1   | Gen2   | Allocated |
|----------------------------- |----------:|-----------:|----------:|-------:|-------:|-------:|----------:|
| SpelNotRow                   |  33.94 ns |  11.613 ns |  0.637 ns | 0.0086 |      - |      - |      72 B |
| SpelNotDynamicRow            |  35.21 ns |  37.163 ns |  2.037 ns | 0.0086 |      - |      - |      72 B |
| SpelNotDictionaryRow         |  34.20 ns |  21.833 ns |  1.197 ns | 0.0086 |      - |      - |      72 B |
| SpelAndRow                   |  52.29 ns |  11.253 ns |  0.617 ns | 0.0086 |      - |      - |      72 B |
| SpelAndDynamicRow            |  55.80 ns |  30.823 ns |  1.690 ns | 0.0086 |      - |      - |      72 B |
| SpelAndDictionaryRow         |  54.41 ns |  22.461 ns |  1.231 ns | 0.0086 |      - |      - |      72 B |
| SpelOrRow                    |  37.19 ns |  33.947 ns |  1.861 ns | 0.0086 |      - |      - |      72 B |
| SpelOrDynamicRow             |  36.89 ns |  11.888 ns |  0.652 ns | 0.0086 |      - |      - |      72 B |
| SpelOrDictionaryRow          |  37.71 ns |   5.825 ns |  0.319 ns | 0.0086 |      - |      - |      72 B |
| SpelTernRow                  | 242.38 ns |  45.655 ns |  2.503 ns | 0.0172 |      - |      - |     144 B |
| SpelTernDynamicRow           | 158.47 ns |  72.118 ns |  3.953 ns | 0.0114 |      - |      - |      96 B |
| VcelDefaultNotRow            |  78.91 ns |  22.579 ns |  1.238 ns | 0.0143 |      - |      - |     120 B |
| VcelDefaultNotDynamicRow     |  81.70 ns | 102.235 ns |  5.604 ns | 0.0143 |      - |      - |     120 B |
| VcelDefaultNotDictionaryRow  |  86.55 ns |  62.511 ns |  3.426 ns | 0.0143 |      - |      - |     120 B |
| VcelDefaultAndRow            |  44.50 ns |  35.181 ns |  1.928 ns | 0.0067 |      - |      - |      56 B |
| VcelDefaultAndDynamicRow     |  47.74 ns |  33.021 ns |  1.810 ns | 0.0067 |      - |      - |      56 B |
| VcelDefaultAndDictionaryRow  |  42.99 ns |  16.617 ns |  0.911 ns | 0.0067 |      - |      - |      56 B |
| VcelDefaultOrRow             |  32.31 ns |  37.681 ns |  2.065 ns | 0.0067 |      - |      - |      56 B |
| VcelDefaultOrDynamicRow      |  31.84 ns |  14.726 ns |  0.807 ns | 0.0067 |      - |      - |      56 B |
| VcelDefaultOrDictionaryRow   |  35.14 ns |  15.939 ns |  0.874 ns | 0.0067 |      - |      - |      56 B |
| VcelDefaultTernRow           | 200.44 ns |  31.247 ns |  1.713 ns | 0.0162 |      - |      - |     136 B |
| VcelDefaultTernDynamicRow    |  73.19 ns | 250.873 ns | 13.751 ns | 0.0038 |      - |      - |      32 B |
| VcelDefaultTernDictionaryRow |  65.65 ns |  61.825 ns |  3.389 ns | 0.0038 |      - |      - |      32 B |
| VcelMaybeNotRow              |  94.26 ns |  37.176 ns |  2.038 ns | 0.0143 |      - |      - |     120 B |
| VcelMaybeNotDynamicRow       |  85.58 ns |  20.437 ns |  1.120 ns | 0.0143 |      - |      - |     120 B |
| VcelMaybeNotDictionaryRow    | 108.78 ns |  19.052 ns |  1.044 ns | 0.0143 |      - |      - |     120 B |
| VcelMaybeAndRow              |  50.24 ns |  32.894 ns |  1.803 ns | 0.0067 |      - |      - |      56 B |
| VcelMaybeAndDynamicRow       |  49.92 ns |  12.783 ns |  0.701 ns | 0.0067 |      - |      - |      56 B |
| VcelMaybeAndDictionaryRow    |  48.50 ns |  49.096 ns |  2.691 ns | 0.0067 |      - |      - |      56 B |
| VcelMaybeOrRow               |  33.89 ns |  10.521 ns |  0.577 ns | 0.0067 |      - |      - |      56 B |
| VcelMaybeOrDynamicRow        |  34.24 ns |  14.022 ns |  0.769 ns | 0.0067 |      - |      - |      56 B |
| VcelMaybeOrDictionaryRow     |  34.30 ns |  11.221 ns |  0.615 ns | 0.0067 |      - |      - |      56 B |
| VcelMaybeTernRow             | 246.02 ns | 269.451 ns | 14.770 ns | 0.0162 |      - |      - |     136 B |
| VcelMaybeTernDynamicRow      |  80.52 ns |  38.873 ns |  2.131 ns | 0.0038 |      - |      - |      32 B |
| VcelMaybeTernDictionaryRow   |  77.29 ns |   7.575 ns |  0.415 ns | 0.0038 |      - |      - |      32 B |
| CSharpNotRow                 |  14.76 ns |   2.227 ns |  0.122 ns | 0.0067 |      - |      - |      56 B |
| CSharpNotDynamicRow          |  14.28 ns |   4.390 ns |  0.241 ns | 0.0067 |      - |      - |      56 B |
| CSharpNotDictionaryRow       |  14.56 ns |  12.488 ns |  0.684 ns | 0.0067 |      - |      - |      56 B |
| CSharpAndRow                 |  15.44 ns |  10.132 ns |  0.555 ns | 0.0067 |      - |      - |      56 B |
| CSharpAndDynamicRow          |  15.28 ns |  11.920 ns |  0.653 ns | 0.0067 |      - |      - |      56 B |
| CSharpAndDictionaryRow       |  14.77 ns |   1.908 ns |  0.105 ns | 0.0067 |      - |      - |      56 B |
| CSharpOrRow                  |  14.13 ns |   5.193 ns |  0.285 ns | 0.0067 | 0.0000 | 0.0000 |      56 B |
| CSharpOrDynamicRow           |  14.67 ns |   5.921 ns |  0.325 ns | 0.0067 | 0.0000 |      - |      56 B |
| CSharpOrDictionaryRow        |  14.81 ns |  10.452 ns |  0.573 ns | 0.0067 |      - |      - |      56 B |
| CSharpTernRow                | 179.54 ns | 111.751 ns |  6.125 ns | 0.0324 | 0.0002 |      - |     272 B |
| CSharpTernDynamicRow         |  92.57 ns |  35.459 ns |  1.944 ns | 0.0267 |      - |      - |     224 B |