### PR TITLE
VC-11652 adding benchmark for in

### DIFF
--- a/src/Tests/VCEL.Benchmark/InBenchmarkTests.cs
+++ b/src/Tests/VCEL.Benchmark/InBenchmarkTests.cs
@@ -1,0 +1,70 @@
+﻿using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using VCEL.Core.Lang;
+using VCEL.CSharp;
+using VCEL.Monad.Maybe;
+
+namespace VCEL.Benchmark;
+
+[SimpleJob(RuntimeMoniker.Net60)]
+[MemoryDiagnoser]
+public class InBenchmarkTests
+{
+    private static readonly ObjectContext<object> context = new ();
+    private readonly IExpression<object?> vcelExpressionFor10Items;
+    private readonly IExpression<object?> vcelExpressionFor50Items;
+    private readonly IExpression<object?> vcelExpressionFor100Items;
+    private readonly IExpression<object?> csharpExpressionFor10Items;
+    private readonly IExpression<object?> csharpExpressionFor50Items;
+    private readonly IExpression<object?> csharpExpressionFor100Items;
+
+    public InBenchmarkTests()
+    {
+        var vcelString10 = $"{{{string.Join(", ", Enumerable.Range(1, 10).Select(i => $"'ABCDE{i}'"))}}}";
+        var vcelString50 = $"{{{string.Join(", ", Enumerable.Range(1, 50).Select(i => $"'ABCDE{i}'"))}}}";
+        var vcelString100 = $"{{{string.Join(", ", Enumerable.Range(1, 100).Select(i => $"'ABCDE{i}'"))}}}";
+        vcelExpressionFor10Items = VCExpression.ParseDefault(vcelString10).Expression;
+        csharpExpressionFor10Items = CSharpExpression.ParseDelegate(vcelString10).Expression;
+        vcelExpressionFor50Items = VCExpression.ParseDefault(vcelString50).Expression;
+        csharpExpressionFor50Items = CSharpExpression.ParseDelegate(vcelString50).Expression;
+        vcelExpressionFor100Items = VCExpression.ParseDefault(vcelString100).Expression;
+        csharpExpressionFor100Items = CSharpExpression.ParseDelegate(vcelString100).Expression;
+    }
+        
+    [Benchmark]
+    public void VcelCsharp10()
+    {
+        csharpExpressionFor10Items.Evaluate(context);
+    }
+    
+    [Benchmark]
+    public void VcelCsharp50()
+    {
+        csharpExpressionFor50Items.Evaluate(context);
+    }
+    
+    [Benchmark]
+    public void VcelCsharp100()
+    {
+        csharpExpressionFor100Items.Evaluate(context);
+    }
+    
+    [Benchmark]
+    public void VcelCore10()
+    {
+        vcelExpressionFor10Items.Evaluate(context);
+    }
+    
+    [Benchmark]
+    public void VcelCore50()
+    {
+        vcelExpressionFor50Items.Evaluate(context);
+    }
+    
+    [Benchmark]
+    public void VcelCore100()
+    {
+        vcelExpressionFor100Items.Evaluate(context);
+    }
+}

--- a/src/Tests/VCEL.Benchmark/Program.cs
+++ b/src/Tests/VCEL.Benchmark/Program.cs
@@ -9,6 +9,8 @@ namespace VcelBenchmark
         {
             BenchmarkRunner.Run(new BenchmarkRunInfo[]
             {
+                BenchmarkConverter.TypeToBenchmarks(typeof(TypeOperationBenchmarkTests)),
+                BenchmarkConverter.TypeToBenchmarks(typeof(JscodeParserBenchmarkTests)),
                 BenchmarkConverter.TypeToBenchmarks(typeof(InBenchmarkTests))
             });
         }

--- a/src/Tests/VCEL.Benchmark/Program.cs
+++ b/src/Tests/VCEL.Benchmark/Program.cs
@@ -9,8 +9,7 @@ namespace VcelBenchmark
         {
             BenchmarkRunner.Run(new BenchmarkRunInfo[]
             {
-                BenchmarkConverter.TypeToBenchmarks(typeof(TypeOperationBenchmarkTests)),
-                BenchmarkConverter.TypeToBenchmarks(typeof(JscodeParserBenchmarkTests))
+                BenchmarkConverter.TypeToBenchmarks(typeof(InBenchmarkTests))
             });
         }
     }


### PR DESCRIPTION
Adding a benchmark for the "in" operator
![image](https://github.com/user-attachments/assets/0d3735c3-94e4-4780-973e-a96a9fb9f5e8)
