### PR TITLE
Remove .NET 6 build step

### DIFF
--- a/.github/workflows/dotnet-core-publish.yml
+++ b/.github/workflows/dotnet-core-publish.yml
@@ -16,10 +16,6 @@ jobs:
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Setup package source
       run: dotnet nuget add source https://nuget.pkg.github.com/EclipseTrading/index.json -n github -u EclipseTrading -p ${{secrets.GITHUB_TOKEN}} --store-password-in-clear-text
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
     - name: Setup .NET 8
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -15,10 +15,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
     - name: Setup .NET 8
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
PR #89 upgraded the project to target .NET 8 only. The .NET 6 build step can now be removed.