### PR TITLE
For VCEL.JS switch from Number.isNaN to global isNaN to support objects that implement valueOf()

### DIFF
--- a/src/Tests/VCEL.Test/ToJSCodeTests.cs
+++ b/src/Tests/VCEL.Test/ToJSCodeTests.cs
@@ -143,7 +143,7 @@ public class ToJsCodeTests
     [TestCase("tan(x)", "(Math.tan(vcelContext.x))")]
     [TestCase("tanh(x)", "(Math.tanh(vcelContext.x))")]
     [TestCase("truncate(x)", "(Math.trunc(vcelContext.x))")]
-    [TestCase("isNaN(x)", "(Number.isNaN(vcelContext.x))")]
+    [TestCase("isNaN(x)", "(isNaN(vcelContext.x))")]
     [TestCase("string(x)", "(String(vcelContext.x))")]
     [TestCase("string(date(1583310915341))", "(String((new Date(1583310915341))))")]
     [TestCase("now()", "(new Date())")]

--- a/src/VCEL.Core/VCEL.Core.csproj
+++ b/src/VCEL.Core/VCEL.Core.csproj
@@ -15,6 +15,7 @@
             <Error>true</Error>
             <Listener>false</Listener>
             <Package>VCEL.Core</Package>
+            <!-- Requires Java v11 or later: https://github.com/kaby76/Antlr4BuildTasks -->
             <JavaExec Condition="'$(OS)' == 'Windows_NT'">$(JAVA_HOME)\bin\java.exe</JavaExec>
             <JavaExec Condition="'$(OS)' != 'Windows_NT'">/usr/bin/java</JavaExec>
         </Antlr4>
@@ -22,6 +23,7 @@
             <Error>true</Error>
             <Listener>false</Listener>
             <Package>VCEL.Core.Lang</Package>
+            <!-- Requires Java v11 or later: https://github.com/kaby76/Antlr4BuildTasks -->
             <JavaExec Condition="'$(OS)' == 'Windows_NT'">$(JAVA_HOME)\bin\java.exe</JavaExec>
             <JavaExec Condition="'$(OS)' != 'Windows_NT'">/usr/bin/java</JavaExec>
         </Antlr4>

--- a/src/VCEL.JS/Expression/ToJsFunction.cs
+++ b/src/VCEL.JS/Expression/ToJsFunction.cs
@@ -35,7 +35,7 @@ internal class ToJsFunction : IExpression<string>
             { "tan", (context, args) => Func(context, args, "Math.tan") },
             { "tanh", (context, args) => Func(context, args, "Math.tanh") },
             { "truncate", (context, args) => Func(context, args, "Math.trunc") },
-            { "isNaN", (context, args) => Func(context, args, "Number.isNaN") },
+            { "isNaN", (context, args) => Func(context, args, "isNaN") },
 
             { "double", (context, args) => Func(context, args, "Number") },
             { "decimal", (context, args) => Func(context, args, "Number") },


### PR DESCRIPTION
Support for `isNaN()` function was added in #91. Where VCEL.JS's implementation uses `Number.isNaN()` which is stricter and more efficient compared to global `isNaN()` by not converting to Number first. However, this can lead to a regression if an object is used that has support for `valueOf()` and returns a `NaN`, but the `Number.isNaN()` would ignore that object because it is not a Number.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN

> As opposed to the global [isNaN()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN) function, the Number.isNaN() method doesn't force-convert the parameter to a number. This makes it safe to pass values that would normally convert to [NaN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN) but aren't actually the same value as [NaN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN). This also means that only values of the Number type that are also [NaN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN) return true.

This PR changes the behavior to use the global `isNaN()` so that objects with `valueOf()` that return a `NaN` also returns `true` for the VCEL `isNaN()` function.